### PR TITLE
Add JSON value wrapper interface to support expression evaluations on ty...

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/eval/ExpressionEvaluator.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/eval/ExpressionEvaluator.java
@@ -14,6 +14,8 @@
  */
 package com.jayway.jsonpath.internal.filter.eval;
 
+import com.jayway.jsonpath.spi.JsonValueWrapper;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collections;
@@ -58,7 +60,12 @@ public class ExpressionEvaluator {
     }
 
 
-    public static <T> boolean eval(T actual, String comparator, String expected) {
+    public static <T> boolean eval(T actualObject, String comparator, String expected) {
+
+        Object actual = actualObject;
+        if(actualObject != null && actualObject instanceof JsonValueWrapper) {
+            actual = ((JsonValueWrapper)actualObject).getValue();
+        }
 
         Operator operator = operatorsByRepresentation.get(comparator);
         if (operator == null) {

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/JsonValueWrapper.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/JsonValueWrapper.java
@@ -1,0 +1,10 @@
+package com.jayway.jsonpath.spi;
+
+/**
+ * Interface to allow wrapping a JSON value to maintain metadata associated with the value
+ *
+ * @author Mike Buchanan
+ */
+public interface JsonValueWrapper<T> {
+    public T getValue();
+}


### PR DESCRIPTION
The ExpressionEvaluator class is not very flexible. Added a simple interface to the SPI as a hook to allow use cases such as the one described below.

My use case must maintain metadata associated with JSON values - offsets in the source document.  To accomplish this, I created the following:
1. a JsonProvider to wrap/unwrap values/arrays/maps as necessary
2. an extension of JSONParserString to override readArray, readObject, and readMain to get offsets and return one of the classes described below.
3. an extension of JSONArray, adding an Offset field
4. an extension of JSONObject, adding an Offset field
5. a wrapper class with an Offset field and an Object - to be used where a String, Boolean, or Number would otherwise be used

This covered all of my needs except evaluating expressions such as $.store.book[?(@.price > 10)].  The ExpressionEvaluator class assumes it will receive a String, Boolean, or Number.


What steps will reproduce the problem?
1. Create a class with an Object field.
2. Create an instance of the class with the field set to new Double(8.95)
3. call ExpressionEvaluator.eval() with your object, "<", "10"

```
public class WrappedJsonValue {
    Object value;

    public WrappedJsonValue(Object value) {
        this.value = value;
    }

    public Object getValue() {
        return value;
    }

    public static void main(String[] args) {
        boolean result = ExpressionEvaluator.eval(new WrappedValue(new Double(8.95)), "<", "10");
        System.out.println(result);
    }
}
```

What is the expected output? What do you see instead?
I would like it to evaluate the Double and return true.  Instead, it returns false because it can't handle a WrappedJsonValue object.