### PR TITLE
Moving JsonProvider and MappingProvider implementations out of the interal package. 

### DIFF
--- a/json-path-web-test/src/main/java/com/jayway/jsonpath/web/bench/Bench.java
+++ b/json-path-web-test/src/main/java/com/jayway/jsonpath/web/bench/Bench.java
@@ -3,7 +3,7 @@ package com.jayway.jsonpath.web.bench;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
-import com.jayway.jsonpath.internal.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import io.gatling.jsonpath.JsonPath$;
 import org.boon.json.JsonParser;
 import org.boon.json.ObjectMapper;

--- a/json-path/src/main/java/com/jayway/jsonpath/Configuration.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Configuration.java
@@ -14,8 +14,8 @@
  */
 package com.jayway.jsonpath;
 
-import com.jayway.jsonpath.internal.spi.json.JsonSmartJsonProvider;
-import com.jayway.jsonpath.internal.spi.mapper.JsonSmartMappingProvider;
+import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JsonSmartMappingProvider;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import com.jayway.jsonpath.spi.mapper.MappingProvider;
 import org.slf4j.Logger;

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/AbstractJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/AbstractJsonProvider.java
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jayway.jsonpath.internal.spi.json;
+package com.jayway.jsonpath.spi.json;
 
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.spi.json.JsonProvider;

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/GsonJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/GsonJsonProvider.java
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jayway.jsonpath.internal.spi.json;
+package com.jayway.jsonpath.spi.json;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonNodeJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonNodeJsonProvider.java
@@ -1,4 +1,4 @@
-package com.jayway.jsonpath.internal.spi.json;
+package com.jayway.jsonpath.spi.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonProvider.java
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jayway.jsonpath.internal.spi.json;
+package com.jayway.jsonpath.spi.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonSmartJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonSmartJsonProvider.java
@@ -12,11 +12,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jayway.jsonpath.internal.spi.json;
+package com.jayway.jsonpath.spi.json;
 
 import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPathException;
-import com.jayway.jsonpath.spi.json.Mode;
+
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import net.minidev.json.JSONStyle;

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/mapper/Factory.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/mapper/Factory.java
@@ -1,4 +1,4 @@
-package com.jayway.jsonpath.internal.spi.mapper;
+package com.jayway.jsonpath.spi.mapper;
 
 public interface Factory<T> {
 

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/mapper/GsonMappingProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/mapper/GsonMappingProvider.java
@@ -12,17 +12,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jayway.jsonpath.internal.spi.mapper;
+package com.jayway.jsonpath.spi.mapper;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.TypeRef;
-import com.jayway.jsonpath.spi.mapper.MappingException;
-import com.jayway.jsonpath.spi.mapper.MappingProvider;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/mapper/JacksonMappingProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/mapper/JacksonMappingProvider.java
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jayway.jsonpath.internal.spi.mapper;
+package com.jayway.jsonpath.spi.mapper;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/mapper/JsonSmartMappingProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/mapper/JsonSmartMappingProvider.java
@@ -12,27 +12,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jayway.jsonpath.internal.spi.mapper;
+package com.jayway.jsonpath.spi.mapper;
 
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.TypeRef;
-import com.jayway.jsonpath.spi.mapper.MappingException;
-import com.jayway.jsonpath.spi.mapper.MappingProvider;
-import net.minidev.json.JSONUtil;
+
 import net.minidev.json.JSONValue;
 import net.minidev.json.writer.JsonReader;
 import net.minidev.json.writer.JsonReaderI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.ParseException;
-import java.util.Collection;
 import java.util.Date;
-import java.util.Map;
 
 public class JsonSmartMappingProvider implements MappingProvider {
 

--- a/json-path/src/test/java/com/jayway/jsonpath/BaseTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/BaseTest.java
@@ -1,11 +1,11 @@
 package com.jayway.jsonpath;
 
 import com.jayway.jsonpath.internal.Path;
-import com.jayway.jsonpath.internal.spi.json.GsonJsonProvider;
-import com.jayway.jsonpath.internal.spi.json.JacksonJsonNodeJsonProvider;
-import com.jayway.jsonpath.internal.spi.json.JacksonJsonProvider;
-import com.jayway.jsonpath.internal.spi.mapper.GsonMappingProvider;
-import com.jayway.jsonpath.internal.spi.mapper.JacksonMappingProvider;
+import com.jayway.jsonpath.spi.json.GsonJsonProvider;
+import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.mapper.GsonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import com.jayway.jsonpath.internal.token.PredicateContextImpl;
 
 import java.util.HashMap;

--- a/json-path/src/test/java/com/jayway/jsonpath/old/JsonProviderTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/old/JsonProviderTest.java
@@ -1,6 +1,6 @@
 package com.jayway.jsonpath.old;
 
-import com.jayway.jsonpath.internal.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import org.junit.Test;
 
 public class JsonProviderTest {


### PR DESCRIPTION
The internal package is not listed as an export in the OSGI manifest. This change allows client code to configure different json providers and mapping providers (as intended) when running in an OSGI container.
````
JacksonJsonProvider jacksonJsonProvider = new JacksonJsonProvider(objectMapper);
Configuration jwayConfiguration = Configuration.defaultConfiguration().jsonProvider(jacksonJsonProvider);
````
Previously the above code will compile and run in a non-OSGI container, but will throw a runtime exception in an OSGI container. The internal package housing the JacksonJsonProvider was not accessible by external bundles.
