### PR TITLE
Fix for https://code.google.com/p/json-path/issues/detail?id=68

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/DefaultsImpl.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/DefaultsImpl.java
@@ -1,0 +1,37 @@
+package com.jayway.jsonpath.internal;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import com.jayway.jsonpath.Configuration.Defaults;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JsonSmartMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+
+public final class DefaultsImpl implements Defaults {
+
+  public static final DefaultsImpl INSTANCE = new DefaultsImpl();
+
+  private final MappingProvider mappingProvider = new JsonSmartMappingProvider();
+
+  @Override
+  public JsonProvider jsonProvider() {
+    return new JsonSmartJsonProvider();
+  }
+
+  @Override
+  public Set<Option> options() {
+    return EnumSet.noneOf(Option.class);
+  }
+
+  @Override
+  public MappingProvider mappingProvider() {
+    return mappingProvider;
+  }
+
+  private DefaultsImpl() {
+  };
+
+}


### PR DESCRIPTION
I moved the default `Defaults` implementation to a separate class that is only loaded when needed, this makes it possible to exclude the json-smart dependency (see https://code.google.com/p/json-path/issues/detail?id=68).