### PR TITLE
Fix array out of bounds exception on '$.' path expression

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/PathCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/PathCompiler.java
@@ -109,7 +109,7 @@ public class PathCompiler {
                         break;
                     case PERIOD:
                         i++;
-                        if (path.charAt(i) == PERIOD) {
+                        if ( i < path.length() && path.charAt(i) == PERIOD) {
                             //This is a deep scan
                             fragment = "..";
                             i++;


### PR DESCRIPTION
The path expression '$.' causes an array out of bounds exception,
I changed it to proceed without looking for ".." .
The result is returning the whole node.  Testing on http://ashphy.com/JSONPathOnlineEvaluator/? that appears to be reasonable behaviour.

-David