### PR TITLE
RenameKey funcionality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'signing'
     apply plugin: 'osgi'
+    apply plugin: 'maven'
 
     sourceCompatibility = 1.6
     targetCompatibility = 1.6

--- a/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
@@ -276,6 +276,17 @@ public class JsonPath {
         return resultByConfiguration(jsonObject, configuration, evaluationContext);
     }
 
+    public <T> T renameKey(Object jsonObject, String oldKeyName, String newKeyName, Configuration configuration){
+        notNull(jsonObject, "json can not be null");
+        notEmpty(newKeyName, "newKeyName can not be null or empty");
+        notNull(configuration, "configuration can not be null");
+        EvaluationContext evaluationContext = path.evaluate(jsonObject, jsonObject, configuration, true);
+        for (PathRef updateOperation : evaluationContext.updateOperations()) {
+            updateOperation.renameKey(oldKeyName, newKeyName, configuration);
+        }
+        return resultByConfiguration(jsonObject, configuration, evaluationContext);
+    }
+
     /**
      * Applies this JsonPath to the provided json string
      *

--- a/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
@@ -15,12 +15,7 @@
 package com.jayway.jsonpath;
 
 
-import com.jayway.jsonpath.internal.EvaluationContext;
-import com.jayway.jsonpath.internal.JsonReader;
-import com.jayway.jsonpath.internal.Path;
-import com.jayway.jsonpath.internal.PathCompiler;
-import com.jayway.jsonpath.internal.PathRef;
-import com.jayway.jsonpath.internal.Utils;
+import com.jayway.jsonpath.internal.*;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 
 import java.io.File;
@@ -217,6 +212,17 @@ public class JsonPath {
         }
         return resultByConfiguration(jsonObject, configuration, evaluationContext);
     }
+
+    public <T> T convert(Object jsonObject, ValueConverter valueConverter, Configuration configuration) {
+        notNull(jsonObject, "json can not be null");
+        notNull(configuration, "configuration can not be null");
+        EvaluationContext evaluationContext = path.evaluate(jsonObject, jsonObject, configuration, true);
+        for (PathRef updateOperation : evaluationContext.updateOperations()) {
+            updateOperation.convert(valueConverter, configuration);
+        }
+        return resultByConfiguration(jsonObject, configuration, evaluationContext);
+    }
+
 
     /**
      * Deletes the object this path points to in the provided jsonObject

--- a/json-path/src/main/java/com/jayway/jsonpath/WriteContext.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/WriteContext.java
@@ -148,7 +148,4 @@ public interface WriteContext {
      */
     DocumentContext renameKey(JsonPath path, String oldKeyName, String newKeyName);
 
-//    DocumentContext replace(String path, String newKey, Predicate... filters);
-//    DocumentContext replace(JsonPath path, String newKey);
-
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/WriteContext.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/WriteContext.java
@@ -116,6 +116,7 @@ public interface WriteContext {
      */
     DocumentContext put(String path, String key, Object value, Predicate... filters);
 
+
     /**
      * Add or update the key with a the given value at the given path
      *
@@ -125,5 +126,29 @@ public interface WriteContext {
      * @return a document context
      */
     DocumentContext put(JsonPath path, String key, Object value);
+
+    /**
+     * Renames the last key element of a given path.
+     * @param path          The path to the old key. Should be resolved to a map
+     *                      or an array including map items.
+     * @param oldKeyName    The old key name.
+     * @param newKeyName    The new key name.
+     * @param filters       filters.
+     * @return a document content.
+     */
+    DocumentContext renameKey(String path, String oldKeyName, String newKeyName, Predicate... filters);
+
+    /**
+     * Renames the last key element of a given path.
+     * @param path          The path to the old key. Should be resolved to a map
+     *                      or an array including map items.
+     * @param oldKeyName    The old key name.
+     * @param newKeyName    The new key name.
+     * @return a document content.
+     */
+    DocumentContext renameKey(JsonPath path, String oldKeyName, String newKeyName);
+
+//    DocumentContext replace(String path, String newKey, Predicate... filters);
+//    DocumentContext replace(JsonPath path, String newKey);
 
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/WriteContext.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/WriteContext.java
@@ -14,6 +14,8 @@
  */
 package com.jayway.jsonpath;
 
+import com.jayway.jsonpath.internal.ValueConverter;
+
 public interface WriteContext {
 
     /**
@@ -55,6 +57,25 @@ public interface WriteContext {
      * @return a document context
      */
     DocumentContext set(JsonPath path, Object newValue);
+
+    /**
+     * Converts the value on the given path.
+     *
+     * @param path              path to be converted set
+     * @param valueConverter    Converter object to be invoked (or lambda:))
+     * @param filters           filters
+     * @return a document context
+     */
+    DocumentContext convert(String path, ValueConverter valueConverter, Predicate... filters);
+
+    /**
+     * Converts the value on the given path.
+     *
+     * @param path              path to be converted set
+     * @param valueConverter    Converter object to be invoked (or lambda:))
+     * @return a document context
+     */
+    DocumentContext convert(JsonPath path, ValueConverter valueConverter);
 
     /**
      * Deletes the given path

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonReader.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonReader.java
@@ -232,6 +232,23 @@ public class JsonReader implements ParseContext, DocumentContext {
     }
 
     @Override
+    public DocumentContext renameKey(String path, String oldKeyName, String newKeyName, Predicate... filters) {
+        return renameKey(compile(path, filters), oldKeyName, newKeyName);
+    }
+
+    @Override
+    public DocumentContext renameKey(JsonPath path, String oldKeyName, String newKeyName) {
+        List<String> modified =  path.renameKey(json, oldKeyName, newKeyName, configuration.addOptions(Option.AS_PATH_LIST));
+        if(logger.isDebugEnabled()){
+            for (String p : modified) {
+                logger.debug("Rename path {} new value {}", p, newKeyName);
+            }
+        }
+        return this;
+    }
+
+
+    @Override
     public DocumentContext put(JsonPath path, String key, Object value){
         List<String> modified = path.put(json, key, value, configuration.addOptions(Option.AS_PATH_LIST));
         if(logger.isDebugEnabled()){

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonReader.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonReader.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import java.util.List;
 
 import static com.jayway.jsonpath.JsonPath.compile;
+import static com.jayway.jsonpath.JsonPath.parse;
 import static com.jayway.jsonpath.internal.Utils.notEmpty;
 import static com.jayway.jsonpath.internal.Utils.notNull;
 
@@ -191,6 +192,18 @@ public class JsonReader implements ParseContext, DocumentContext {
                 logger.debug("Set path {} new value {}", p, newValue);
             }
         }
+        return this;
+    }
+
+    @Override
+    public DocumentContext convert(String path, ValueConverter valueConverter, Predicate... filters) {
+        convert(compile(path, filters), valueConverter);
+        return this;
+    }
+
+    @Override
+    public DocumentContext convert(JsonPath path, ValueConverter valueConverter) {
+        path.convert(json, valueConverter, configuration);
         return this;
     }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/PathRef.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/PathRef.java
@@ -4,6 +4,7 @@ import com.jayway.jsonpath.*;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 
 import java.util.Collection;
+import java.util.List;
 
 public abstract class PathRef implements Comparable<PathRef>  {
 
@@ -138,10 +139,12 @@ public abstract class PathRef implements Comparable<PathRef>  {
     private static class ArrayIndexPathRef extends PathRef {
 
         private int index;
+        private Object value;
 
         private ArrayIndexPathRef(Object parent, int index) {
             super(parent);
             this.index = index;
+            this.value = ((List<Object>) parent).get(index);
         }
 
         public void set(Object newVal, Configuration configuration){
@@ -149,7 +152,7 @@ public abstract class PathRef implements Comparable<PathRef>  {
         }
 
         public void delete(Configuration configuration){
-            configuration.jsonProvider().removeProperty(parent, index);
+            configuration.jsonProvider().removeProperty(parent, value);
         }
 
         public void add(Object value, Configuration configuration){

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/PathRef.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/PathRef.java
@@ -1,9 +1,6 @@
 package com.jayway.jsonpath.internal;
 
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.InvalidModificationException;
-import com.jayway.jsonpath.InvalidPathException;
-import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.*;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 
 import java.util.Collection;
@@ -55,7 +52,7 @@ public abstract class PathRef implements Comparable<PathRef>  {
     protected void renameInMap(Object targetMap, String oldKeyName, String newKeyName, Configuration configuration){
         if(configuration.jsonProvider().isMap(targetMap)){
             if(configuration.jsonProvider().getMapValue(targetMap, oldKeyName) == JsonProvider.UNDEFINED){
-                throw new InvalidPathException("Key "+oldKeyName+" not found in map!");
+                throw new PathNotFoundException("No results for Key "+oldKeyName+" found in map!");
             }
             configuration.jsonProvider().setProperty(targetMap, newKeyName, configuration.jsonProvider().getMapValue(targetMap, oldKeyName));
             configuration.jsonProvider().removeProperty(targetMap, oldKeyName);

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/PathRef.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/PathRef.java
@@ -18,6 +18,9 @@ public abstract class PathRef implements Comparable<PathRef>  {
         public void set(Object newVal, Configuration configuration) {}
 
         @Override
+        public void convert(ValueConverter valueConverter, Configuration configuration) {}
+
+        @Override
         public void delete(Configuration configuration) {}
 
         @Override
@@ -41,6 +44,8 @@ public abstract class PathRef implements Comparable<PathRef>  {
     abstract Object getAccessor();
 
     public abstract void set(Object newVal, Configuration configuration);
+
+    public abstract void convert(ValueConverter valueConverter, Configuration configuration);
 
     public abstract void delete(Configuration configuration);
 
@@ -103,6 +108,10 @@ public abstract class PathRef implements Comparable<PathRef>  {
             throw new InvalidModificationException("Invalid delete operation");
         }
 
+        public void convert(ValueConverter valueConverter, Configuration configuration){
+            throw new InvalidModificationException("Invalid convert operation");
+        }
+
         @Override
         public void delete(Configuration configuration) {
             throw new InvalidModificationException("Invalid delete operation");
@@ -136,6 +145,7 @@ public abstract class PathRef implements Comparable<PathRef>  {
         }
 
     }
+
     private static class ArrayIndexPathRef extends PathRef {
 
         private int index;
@@ -149,6 +159,11 @@ public abstract class PathRef implements Comparable<PathRef>  {
 
         public void set(Object newVal, Configuration configuration){
             configuration.jsonProvider().setArrayIndex(parent, index, newVal);
+        }
+
+        public void convert(ValueConverter valueConverter, Configuration configuration){
+            Object currentValue = configuration.jsonProvider().getArrayIndex(parent, index);
+            configuration.jsonProvider().setArrayIndex(parent, index, valueConverter.convert(currentValue));
         }
 
         public void delete(Configuration configuration){
@@ -209,6 +224,13 @@ public abstract class PathRef implements Comparable<PathRef>  {
             configuration.jsonProvider().setProperty(parent, property, newVal);
         }
 
+        @Override
+        public void convert(ValueConverter valueConverter, Configuration configuration) {
+            Object currentValue = configuration.jsonProvider().getMapValue(parent, property);
+            configuration.jsonProvider().setProperty(parent, property, valueConverter.convert(currentValue));
+        }
+
+
         public void delete(Configuration configuration){
             configuration.jsonProvider().removeProperty(parent, property);
         }
@@ -264,6 +286,12 @@ public abstract class PathRef implements Comparable<PathRef>  {
         public void set(Object newVal, Configuration configuration){
             for (String property : properties) {
                 configuration.jsonProvider().setProperty(parent, property, newVal);
+            }
+        }
+        public void convert(ValueConverter valueConverter, Configuration configuration) {
+            for (String property : properties) {
+                Object currentValue = configuration.jsonProvider().getMapValue(parent, property);
+                configuration.jsonProvider().setProperty(parent, property, valueConverter.convert(currentValue));
             }
         }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/PathRef.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/PathRef.java
@@ -2,6 +2,7 @@ package com.jayway.jsonpath.internal;
 
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.InvalidModificationException;
+import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 
@@ -53,6 +54,9 @@ public abstract class PathRef implements Comparable<PathRef>  {
 
     protected void renameInMap(Object targetMap, String oldKeyName, String newKeyName, Configuration configuration){
         if(configuration.jsonProvider().isMap(targetMap)){
+            if(configuration.jsonProvider().getMapValue(targetMap, oldKeyName) == JsonProvider.UNDEFINED){
+                throw new InvalidPathException("Key "+oldKeyName+" not found in map!");
+            }
             configuration.jsonProvider().setProperty(targetMap, newKeyName, configuration.jsonProvider().getMapValue(targetMap, oldKeyName));
             configuration.jsonProvider().removeProperty(targetMap, oldKeyName);
         } else {

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/ValueConverter.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/ValueConverter.java
@@ -1,0 +1,10 @@
+package com.jayway.jsonpath.internal;
+
+/**
+ * Created by tom on 29/04/15.
+ */
+public interface ValueConverter {
+
+    public Object convert(Object currentValue);
+
+}

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/AbstractJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/AbstractJsonProvider.java
@@ -106,16 +106,16 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      * Removes a value in an object or array
      *
      * @param obj   an array or an object
-     * @param key   a String key or a numerical index to remove
+     * @param key   a String key or an object in a Collection to be removed.
      */
     @SuppressWarnings("unchecked")
     public void removeProperty(Object obj, Object key) {
         if (isMap(obj))
             ((Map) obj).remove(key.toString());
         else {
-            List list = (List) obj;
-            int index = key instanceof Integer ? (Integer) key : Integer.parseInt(key.toString());
-            list.remove(index);
+            Collection collection = (Collection) obj;
+            //int index = key instanceof Integer ? (Integer) key : Integer.parseInt(key.toString());
+            collection.remove(key);
         }
     }
 

--- a/json-path/src/test/java/com/jayway/jsonpath/WriteTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/WriteTest.java
@@ -246,7 +246,7 @@ public class WriteTest extends BaseTest {
         parse(JSON_DOCUMENT).renameKey("$.store.book[*]['author', 'category']", "old-key", "new-key");
     }
 
-    @Test(expected = InvalidPathException.class)
+    @Test(expected = PathNotFoundException.class)
     public void non_existent_key_rename_not_allowed(){
         Object o = parse(JSON_DOCUMENT).renameKey("$", "fake", "new-fake").json();
     }

--- a/json-path/src/test/java/com/jayway/jsonpath/WriteTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/WriteTest.java
@@ -123,6 +123,15 @@ public class WriteTest extends BaseTest {
         assertThat(res).containsExactly("reference");
     }
 
+    @Test
+    public void an_array_criteria_with_multiple_results_can_be_deleted(){
+        String deletePath = "$._embedded.mandates[?(@.count=~/0/)]";
+        DocumentContext documentContext = JsonPath.parse(getClass().getResourceAsStream("/json_array_multiple_delete.json"));
+        documentContext.delete(deletePath);
+        List<Object> result = documentContext.read(deletePath);
+        assertThat(result.size()).isEqualTo(0);
+    }
+
 
     @Test
     public void multi_prop_delete() {

--- a/json-path/src/test/java/com/jayway/jsonpath/WriteTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/WriteTest.java
@@ -245,4 +245,9 @@ public class WriteTest extends BaseTest {
     public void multiple_properties_cannot_be_renamed(){
         parse(JSON_DOCUMENT).renameKey("$.store.book[*]['author', 'category']", "old-key", "new-key");
     }
+
+    @Test(expected = InvalidPathException.class)
+    public void non_existent_key_rename_not_allowed(){
+        Object o = parse(JSON_DOCUMENT).renameKey("$", "fake", "new-fake").json();
+    }
 }

--- a/json-path/src/test/java/com/jayway/jsonpath/WriteTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/WriteTest.java
@@ -2,10 +2,7 @@ package com.jayway.jsonpath;
 
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.jayway.jsonpath.JsonPath.parse;
 import static java.util.Collections.emptyMap;
@@ -214,6 +211,38 @@ public class WriteTest extends BaseTest {
         parse(model).set("$[?(@.a == 'a-val')]", 1);
     }
 
+    @Test
+    public void a_path_can_be_renamed(){
+        Object o = parse(JSON_DOCUMENT).renameKey("$.store", "book", "updated-book").json();
+        List<Object> result = parse(o).read("$.store.updated-book");
 
+        assertThat(result).isNotEmpty();
+    }
 
+    @Test
+    public void keys_in_root_containing_map_can_be_renamed(){
+        Object o = parse(JSON_DOCUMENT).renameKey("$", "store", "new-store").json();
+        List<Object> result = parse(o).read("$.new-store[*]");
+        assertThat(result).isNotEmpty();
+    }
+
+    @Test
+    public void map_array_items_can_be_renamed(){
+        Object o = parse(JSON_DOCUMENT).renameKey("$.store.book[*]", "category", "renamed-category").json();
+        List<Object> result = parse(o).read("$.store.book[*].renamed-category");
+        assertThat(result).isNotEmpty();
+    }
+
+    @Test(expected = InvalidModificationException.class)
+    public void non_map_array_items_cannot_be_renamed(){
+        List<Integer> model = new LinkedList<Integer>();
+        model.add(1);
+        model.add(2);
+        parse(model).renameKey("$[*]", "oldKey", "newKey");
+    }
+
+    @Test(expected = InvalidModificationException.class)
+    public void multiple_properties_cannot_be_renamed(){
+        parse(JSON_DOCUMENT).renameKey("$.store.book[*]['author', 'category']", "old-key", "new-key");
+    }
 }

--- a/json-path/src/test/resources/json_array_multiple_delete.json
+++ b/json-path/src/test/resources/json_array_multiple_delete.json
@@ -1,0 +1,54 @@
+{
+  "_embedded": {
+    "mandates": [
+      {
+        "count": "0",
+        "difference": "+0"
+      },
+      {
+        "count": "0",
+        "difference": "+0"
+      },
+      {
+        "count": "0",
+        "difference": "+0"
+      },
+      {
+        "count": "0",
+        "difference": "+0"
+      },
+      {
+        "count": "0",
+        "difference": "+0"
+      },
+      {
+        "count": "10",
+        "difference": "+0"
+      },
+      {
+        "count": "34",
+        "difference": "+0"
+      },
+      {
+        "count": "2",
+        "difference": "+0"
+      },
+      {
+        "count": "4",
+        "difference": "+0"
+      },
+      {
+        "count": "0",
+        "difference": "+0"
+      },
+      {
+        "count": "0",
+        "difference": "+0"
+      },
+      {
+        "count": "0",
+        "difference": "+0"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Added renameKey feature to rename a key value found in a map path to a new key value. This gratly increases the usability of the library. Unit tests were also extended to cover the new feature.