### PR TITLE
fix wired compare result like: "8.9">12

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/Criteria.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Criteria.java
@@ -828,7 +828,12 @@ public class Criteria implements Predicate {
             if (exp.contains("\'")) {
                 exp = exp.replace("\\'", "'");
             }
-            return exp.compareTo((String) right);
+//            return exp.compareTo((String) right);
+	        if(Utils.isNumeric(left.toString()) && Utils.isNumeric(right.toString())) {
+		        return new BigDecimal(left.toString()).compareTo(new BigDecimal(right.toString()));
+	        } else {
+		        return exp.compareTo((String) right);
+	        }
         } else if (left instanceof Number && right instanceof Number) {
             return new BigDecimal(left.toString()).compareTo(new BigDecimal(right.toString()));
         } else if (left instanceof String && right instanceof Number) {


### PR DESCRIPTION
jsonStr = 
{
"store": {
"book": [
{"price": "120"},
{"price": 8.95},
{ "price": 12.99},
{"price": 8.99 },
{ "price": 22.99}
],
},
"expensive": 10
}

jsonPath = "$.store.book[?(@.price <= 90)].price";

before fix: 
return: [120, 8.95, 12.99, 8.99, 22.99]

after fix:
return: [8.95,12.99,8.99,22.99]
