### PR TITLE
Streaming extensions for JsonPath

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/Criteria.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Criteria.java
@@ -16,7 +16,7 @@ package com.jayway.jsonpath;
 
 import com.jayway.jsonpath.internal.Path;
 import com.jayway.jsonpath.internal.PathCompiler;
-import com.jayway.jsonpath.internal.token.PredicateContextImpl;
+import com.jayway.jsonpath.internal.token.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +65,37 @@ public class Criteria implements Predicate {
             }
 
             @Override
+            public boolean check(TokenStackElement left, TokenStackElement right) {
+                if (left.getType() == right.getType()) {
+                    switch (left.getType()) {
+                    case ARRAY_TOKEN:
+                    {
+                        ArrayToken leftT = (ArrayToken)left;
+                        ArrayToken rightT = (ArrayToken)right;
+                        break;
+                    }
+                    case OBJECT_TOKEN:
+                    {
+                        break;
+                    }
+                    case STRING_TOKEN:
+                    {
+                        break;
+                    }
+                    case FLOAT_TOKEN:
+                    {
+                        break;
+                    }
+                    case INTEGER_TOKEN:
+                    {
+                        break;
+                    }
+                    }
+                }
+                return false;
+            }
+
+            @Override
             public String toString() {
                 return "==";
             }
@@ -75,6 +106,11 @@ public class Criteria implements Predicate {
                 boolean res = (0 != safeCompare(expected, model));
                 if (logger.isDebugEnabled()) logger.debug("[{}] {} [{}] => {}", model, name(), expected, res);
                 return res;
+            }
+
+            @Override
+            public boolean check(TokenStackElement left, TokenStackElement right) {
+                return false;
             }
 
             @Override
@@ -94,6 +130,11 @@ public class Criteria implements Predicate {
             }
 
             @Override
+            public boolean check(TokenStackElement left, TokenStackElement right) {
+                return false;
+            }
+
+            @Override
             public String toString() {
                 return ">";
             }
@@ -107,6 +148,11 @@ public class Criteria implements Predicate {
                 boolean res = (0 >= safeCompare(expected, model));
                 if (logger.isDebugEnabled()) logger.debug("[{}] {} [{}] => {}", model, name(), expected, res);
                 return res;
+            }
+
+            @Override
+            public boolean check(TokenStackElement left, TokenStackElement right) {
+                return false;
             }
 
             @Override
@@ -126,6 +172,11 @@ public class Criteria implements Predicate {
             }
 
             @Override
+            public boolean check(TokenStackElement left, TokenStackElement right) {
+                return false;
+            }
+
+            @Override
             public String toString() {
                 return "<";
             }
@@ -139,6 +190,11 @@ public class Criteria implements Predicate {
                 boolean res = (0 <= safeCompare(expected, model));
                 if (logger.isDebugEnabled()) logger.debug("[{}] {} [{}] => {}", model, name(), expected, res);
                 return res;
+            }
+
+            @Override
+            public boolean check(TokenStackElement left, TokenStackElement right) {
+                return false;
             }
 
             @Override
@@ -160,6 +216,11 @@ public class Criteria implements Predicate {
                 if (logger.isDebugEnabled()) logger.debug("[{}] {} [{}] => {}", model, name(), join(", ", exps), res);
                 return res;
             }
+
+            @Override
+            public boolean check(TokenStackElement left, TokenStackElement right) {
+                return false;
+            }
         },
         NIN {
             @Override
@@ -168,6 +229,11 @@ public class Criteria implements Predicate {
                 boolean res = !nexps.contains(model);
                 if (logger.isDebugEnabled()) logger.debug("[{}] {} [{}] => {}", model, name(), join(", ", nexps), res);
                 return res;
+            }
+
+            @Override
+            public boolean check(TokenStackElement left, TokenStackElement right) {
+                return false;
             }
         },
         CONTAINS {
@@ -190,6 +256,11 @@ public class Criteria implements Predicate {
                 }
                 if (logger.isDebugEnabled()) logger.debug("[{}] {} [{}] => {}", model, name(), expected, res);
                 return res;
+            }
+
+            @Override
+            public boolean check(TokenStackElement left, TokenStackElement right) {
+                return false;
             }
         },
         ALL {
@@ -219,6 +290,11 @@ public class Criteria implements Predicate {
                 }
                 return res;
             }
+
+            @Override
+            public boolean check(TokenStackElement left, TokenStackElement right) {
+                return false;
+            }
         },
         SIZE {
             @Override
@@ -240,12 +316,22 @@ public class Criteria implements Predicate {
                 }
                 return res;
             }
+
+            @Override
+            public boolean check(TokenStackElement left, TokenStackElement right) {
+                return false;
+            }
         },
         EXISTS {
             @Override
             boolean eval(Object expected, Object model, PredicateContext ctx) {
                 //This must be handled outside
                 throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean check(TokenStackElement left, TokenStackElement right) {
+                return false;
             }
         },
         TYPE {
@@ -255,6 +341,11 @@ public class Criteria implements Predicate {
                 final Class<?> actType = model == null ? null : model.getClass();
 
                 return actType != null && expType.isAssignableFrom(actType);
+            }
+
+            @Override
+            public boolean check(TokenStackElement left, TokenStackElement right) {
+                return false;
             }
         },
         REGEX {
@@ -281,6 +372,11 @@ public class Criteria implements Predicate {
             }
 
             @Override
+            public boolean check(TokenStackElement left, TokenStackElement right) {
+                return false;
+            }
+
+            @Override
             public String toString() {
                 return "=~";
             }
@@ -291,6 +387,11 @@ public class Criteria implements Predicate {
                 PredicateContextImpl pci = (PredicateContextImpl) ctx;
                 Predicate exp = (Predicate) expected;
                 return exp.apply(new PredicateContextImpl(model, ctx.root(), ctx.configuration(), pci.documentPathCache()));
+            }
+
+            @Override
+            public boolean check(TokenStackElement left, TokenStackElement right) {
+                return false;
             }
         },
         NOT_EMPTY {
@@ -310,9 +411,17 @@ public class Criteria implements Predicate {
                 }
                 return res;
             }
+
+            @Override
+            public boolean check(TokenStackElement left, TokenStackElement right) {
+                return false;
+            }
         };
 
-        abstract boolean eval(Object expected, Object model, PredicateContext ctx);
+        abstract boolean eval(Object expected, Object model,
+                              PredicateContext ctx);
+
+        abstract boolean check(TokenStackElement left, TokenStackElement right);
 
         public static CriteriaType parse(String str) {
             if ("==".equals(str)) {
@@ -414,6 +523,43 @@ public class Criteria implements Predicate {
         }
     }
 
+    @Override
+    public boolean check(TokenStack stack, int idx) {
+        for (Criteria criteria : criteriaChain) {
+            if (!criteria.check2(stack, idx)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean check2(TokenStack stack, int idx) {
+        if (CriteriaType.EXISTS == criteriaType) {
+            boolean exists = ((Boolean) right);
+            try {
+                //Configuration c = Configuration.builder().jsonProvider(ctx.configuration().jsonProvider()).options(Option.REQUIRE_PROPERTIES).build();
+                //Object value = ((Path) left).evaluate(ctx.item(), ctx.root(), c).getValue();
+                Object value = null;
+
+                if (exists) {
+                    return (value != null);
+                } else {
+                    return (value == null);
+                }
+            } catch (PathNotFoundException e) {
+                return !exists;
+            }
+        }
+        try {
+            //Object leftVal = evaluateIfPath(left, ctx);
+            //Object rightVal = evaluateIfPath(right, ctx);
+
+            //return criteriaType.check(rightVal, leftVal);
+        } catch (ValueCompareException e) {
+        } catch (PathNotFoundException e) {
+        }
+        return false;
+    }
 
     /**
      * Static factory method to create a Criteria using the provided key

--- a/json-path/src/main/java/com/jayway/jsonpath/EvaluationCallback.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/EvaluationCallback.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jayway.jsonpath;
+
+import com.jayway.jsonpath.internal.Path;
+
+/**
+ * A listener that can be registered on a {@link com.jayway.jsonpath.internal.token.TokenStack} that is notified when a
+ * result is found for a specific registered path
+ */
+public interface EvaluationCallback {
+
+    /**
+     * Callback invoked when result is found
+     * @param path -- the specific path that was triggered
+     */
+    void resultFound(Path path);
+
+    /**
+     * Callback invoked when the parser leaves the region in which the match
+     * was found
+     * @param path -- the specific path that was untriggered
+     */
+    void resultFoundExit(Path path);
+}

--- a/json-path/src/main/java/com/jayway/jsonpath/Filter.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Filter.java
@@ -15,6 +15,7 @@
 package com.jayway.jsonpath;
 
 import com.jayway.jsonpath.internal.Utils;
+import com.jayway.jsonpath.internal.token.TokenStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +57,8 @@ public abstract class Filter implements Predicate {
     @Override
     public abstract boolean apply(PredicateContext ctx);
 
+    @Override
+    public abstract boolean check(TokenStack stack, int idx);
 
     public Filter or(final Predicate other){
         return new OrFilter(this, other);
@@ -78,6 +81,11 @@ public abstract class Filter implements Predicate {
         @Override
         public boolean apply(PredicateContext ctx) {
             return predicate.apply(ctx);
+        }
+
+        @Override
+        public boolean check(TokenStack stack, int idx) {
+            return predicate.check(stack, idx);
         }
 
         @Override
@@ -115,6 +123,16 @@ public abstract class Filter implements Predicate {
         }
 
         @Override
+        public boolean check(TokenStack stack, int idx) {
+            for (Predicate predicate : predicates) {
+                if(!predicate.check(stack, idx)){
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
         public String toString() {
             return "(" + Utils.join(" && ", predicates) + ")";
         }
@@ -124,7 +142,7 @@ public abstract class Filter implements Predicate {
 
         private final Predicate left;
         private final Predicate right;
-  
+
         private OrFilter(Predicate left, Predicate right) {
             this.left = left;
             this.right = right;
@@ -138,6 +156,12 @@ public abstract class Filter implements Predicate {
         public boolean apply(PredicateContext ctx) {
             boolean a = left.apply(ctx);
             return a || right.apply(ctx);
+        }
+
+        @Override
+        public boolean check(TokenStack stack, int idx) {
+            boolean a = left.check(stack, idx);
+            return a || right.check(stack, idx);
         }
 
         @Override

--- a/json-path/src/main/java/com/jayway/jsonpath/Predicate.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Predicate.java
@@ -14,6 +14,7 @@
  */
 package com.jayway.jsonpath;
 
+import com.jayway.jsonpath.internal.token.TokenStack;
 import com.jayway.jsonpath.spi.mapper.MappingException;
 
 /**
@@ -22,6 +23,8 @@ import com.jayway.jsonpath.spi.mapper.MappingException;
 public interface Predicate {
 
     boolean apply(PredicateContext ctx);
+
+    boolean check(TokenStack stack, int idx);
 
     public interface PredicateContext {
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/CompiledPath.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/CompiledPath.java
@@ -17,6 +17,7 @@ package com.jayway.jsonpath.internal;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.internal.token.EvaluationContextImpl;
 import com.jayway.jsonpath.internal.token.PathToken;
+import com.jayway.jsonpath.internal.token.TokenStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +60,11 @@ public class CompiledPath implements Path {
     @Override
     public EvaluationContext evaluate(Object document, Object rootDocument, Configuration configuration){
         return evaluate(document, rootDocument, configuration, false);
+    }
+
+    @Override
+    public boolean checkForMatch(TokenStack stack) {
+        return root.checkForMatch(stack, 0);
     }
 
     @Override

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/Path.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/Path.java
@@ -15,6 +15,7 @@
 package com.jayway.jsonpath.internal;
 
 import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.internal.token.TokenStack;
 
 /**
  *
@@ -42,6 +43,12 @@ public interface Path {
      * @return EvaluationContext containing results of evaluation
      */
     EvaluationContext evaluate(Object document, Object rootDocument, Configuration configuration, boolean forUpdate);
+
+    /**
+     * checks the parser state represented by stack and determines if this
+     * path matches it
+     */
+    boolean checkForMatch(TokenStack stack);
 
     /**
      *

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/ArrayPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/ArrayPathToken.java
@@ -179,6 +179,85 @@ public class ArrayPathToken extends PathToken {
     }
 
     @Override
+    public boolean checkForMatch(TokenStack stack, int idx)
+    {
+        assert(stack.getStack().size() > idx);
+        TokenStackElement curr = stack.getStack().get(idx);
+
+        if (curr.getType() == TokenType.ARRAY_TOKEN) {
+            ArrayToken token = (ArrayToken)curr;
+            int tokenIdx = token.getIndex();
+            switch (operation) {
+            case CONTEXT_SIZE:
+            {
+                if (isLeaf()) {
+                    return stack.getStack().size() - 1 == idx;
+                }
+                return next().checkForMatch(stack, idx + 1);
+            }
+            case SLICE_TO:
+            {
+                int to = criteria.get(0).intValue();
+                if (tokenIdx < to) {
+                    if (isLeaf()) {
+                        return stack.getStack().size() - 1 == idx;
+                    }
+                    return next().checkForMatch(stack, idx + 1);
+                }
+                break;
+            }
+            case SLICE_FROM:
+            {
+                int from = criteria.get(0).intValue();
+                if (from <= tokenIdx) {
+                    if (isLeaf()) {
+                        return stack.getStack().size() - 1 == idx;
+                    }
+                    return next().checkForMatch(stack, idx + 1);
+                }
+                break;
+            }
+            case SLICE_BETWEEN:
+            {
+                int from = criteria.get(0).intValue();
+                int to = criteria.get(1).intValue();
+                if (from <= tokenIdx && tokenIdx < to) {
+                    if (isLeaf()) {
+                        return stack.getStack().size() - 1 == idx;
+                    }
+                    return next().checkForMatch(stack, idx + 1);
+                }
+                break;
+            }
+            case INDEX_SEQUENCE:
+            {
+                for (Integer i : criteria) {
+                    if (i.intValue() == tokenIdx) {
+                        if (isLeaf()) {
+                            return stack.getStack().size() - 1 == idx;
+                        }
+                        return next().checkForMatch(stack, idx + 1);
+                    }
+                }
+                break;
+            }
+            case SINGLE_INDEX:
+            {
+                if (criteria.get(0).intValue() == tokenIdx) {
+                    if (isLeaf()) {
+                        return stack.getStack().size() - 1 == idx;
+                    }
+                    return next().checkForMatch(stack, idx + 1);
+                }
+                break;
+            }
+            }
+        }
+
+        return false;
+    }
+
+    @Override
     boolean isTokenDefinite() {
         return isDefinite;
     }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/ArrayToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/ArrayToken.java
@@ -1,0 +1,48 @@
+
+package com.jayway.jsonpath.internal.token;
+
+/**
+ *
+ * @author Hunter Payne
+ **/
+public class ArrayToken implements TokenStackElement
+{
+    int currentIndex;
+    TokenStackElement value; // can be an object, array, or property
+
+    public ArrayToken()
+    {
+        currentIndex = 0;
+        value = null;
+    }
+
+    public TokenType getType()
+    {
+        return TokenType.ARRAY_TOKEN;
+    }
+
+    public int getIndex()
+    {
+        return currentIndex;
+    }
+
+    public TokenStackElement getValue()
+    {
+        return value;
+    }
+
+    public void setValue(TokenStackElement elem)
+    {
+        if (value != null) {
+            ++currentIndex;
+        }
+        value = elem;
+    }
+
+    public String toString()
+    {
+        return "Array[idx=" + currentIndex + "]";
+    }
+}
+
+// End ArrayToken.java

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/FloatToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/FloatToken.java
@@ -1,0 +1,33 @@
+
+package com.jayway.jsonpath.internal.token;
+
+/**
+ *
+ * @author Hunter Payne
+ **/
+public class FloatToken implements TokenStackElement
+{
+    public float value;
+
+    public FloatToken(float f)
+    {
+        value = f;
+    }
+
+    public TokenType getType()
+    {
+        return TokenType.FLOAT_TOKEN;
+    }
+
+    public TokenStackElement getValue()
+    {
+        return null;
+    }
+
+    public void setValue(TokenStackElement elem)
+    {
+        throw new RuntimeException();
+    }
+}
+
+// End FloatToken.java

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/IntToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/IntToken.java
@@ -1,0 +1,33 @@
+
+package com.jayway.jsonpath.internal.token;
+
+/**
+ *
+ * @author Hunter Payne
+ **/
+public class IntToken implements TokenStackElement
+{
+    public int value;
+
+    public IntToken(int f)
+    {
+        value = f;
+    }
+
+    public TokenType getType()
+    {
+        return TokenType.INTEGER_TOKEN;
+    }
+
+    public TokenStackElement getValue()
+    {
+        return null;
+    }
+
+    public void setValue(TokenStackElement elem)
+    {
+        throw new RuntimeException();
+    }
+}
+
+// End IntToken.java

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/ObjectToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/ObjectToken.java
@@ -1,0 +1,45 @@
+
+package com.jayway.jsonpath.internal.token;
+
+/**
+ *
+ * @author Hunter Payne
+ **/
+public class ObjectToken implements TokenStackElement
+{
+    String key;
+    TokenStackElement value; // can be an array, object, or property
+
+    public ObjectToken()
+    {
+        key = null;
+        value = null;
+    }
+
+    public TokenType getType()
+    {
+        return TokenType.OBJECT_TOKEN;
+    }
+
+    public String getKey()
+    {
+        return key;
+    }
+
+    public TokenStackElement getValue()
+    {
+        return value;
+    }
+
+    public void setValue(TokenStackElement elem)
+    {
+        value = elem;
+    }
+
+    public String toString()
+    {
+        return "Object[key=" + key + "]";
+    }
+}
+
+// End ObjectToken.java

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/PathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/PathToken.java
@@ -204,6 +204,9 @@ public abstract class PathToken {
 
     public abstract void evaluate(String currentPath, PathRef parent,  Object model, EvaluationContextImpl ctx);
 
+    /** streaming API */
+    public abstract boolean checkForMatch(TokenStack stack, int idx);
+
     abstract boolean isTokenDefinite();
 
     abstract String getPathFragment();

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/PredicateContextImpl.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/PredicateContextImpl.java
@@ -66,7 +66,7 @@ public class PredicateContextImpl implements Predicate.PredicateContext {
 
     @Override
     public <T> T item(Class<T> clazz) throws MappingException {
-        return  configuration().mappingProvider().map(contextDocument, clazz, configuration);
+        return configuration().mappingProvider().map(contextDocument, clazz, configuration);
     }
 
     @Override

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/PredicatePathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/PredicatePathToken.java
@@ -77,11 +77,40 @@ public class PredicatePathToken extends PathToken {
         Predicate.PredicateContext ctx = new PredicateContextImpl(obj, root, configuration, evaluationContext.documentEvalCache());
 
         for (Predicate predicate : predicates) {
-            if (!predicate.apply (ctx)) {
+            if (!predicate.apply(ctx)) {
                 return false;
             }
         }
         return true;
+    }
+
+    private StackElementWrapper wrapper = null;
+
+    @Override
+    public boolean checkForMatch(TokenStack stack, int idx)
+    {
+        assert(stack.getStack().size() > idx);
+        TokenStackElement curr = stack.getStack().get(idx);
+
+        if (curr.getType() == TokenType.ARRAY_TOKEN || curr.getType() == TokenType.OBJECT_TOKEN) {
+            if (null == wrapper) {
+                wrapper = new StackElementWrapper(stack, idx);
+            } else {
+                wrapper.reset(idx);
+            }
+
+            for (Predicate predicate : predicates) {
+                if (!predicate.apply(wrapper)) {
+                    //if (!predicate.check(stack, idx)) {
+                    return false;
+                }
+            }
+            if (isLeaf()) {
+                return stack.getStack().size() - 1 == idx;
+            }
+            return next().checkForMatch(stack, idx + 1);
+        }
+        return false;
     }
 
     @Override

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/RootPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/RootPathToken.java
@@ -55,6 +55,16 @@ public class RootPathToken extends PathToken {
     }
 
     @Override
+    public boolean checkForMatch(TokenStack stack, int idx)
+    {
+        assert(0 == idx);
+        if (0 == stack.getStack().size()) {
+            return isLeaf();
+        }
+        return !isLeaf() && next().checkForMatch(stack, 0);
+    }
+
+    @Override
     public String getPathFragment() {
         return "$";
     }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/ScanPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/ScanPathToken.java
@@ -96,6 +96,28 @@ public class ScanPathToken extends PathToken {
         }
     }
 
+    @Override
+    public boolean checkForMatch(TokenStack stack, int idx)
+    {
+        assert(stack.getStack().size() > idx);
+        TokenStackElement curr = stack.getStack().get(idx);
+
+        if (curr.getType() == TokenType.ARRAY_TOKEN
+            || curr.getType() == TokenType.OBJECT_TOKEN)
+        {
+            //if ((idx - 1) == stack.getStack().size() && isLeaf())
+            if (isLeaf()) {
+                return true;
+            }
+            for (int i = idx; i < stack.getStack().size(); ++i) {
+                if (next().checkForMatch(stack, i)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 
     @Override
     boolean isTokenDefinite() {

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/StackElementWrapper.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/StackElementWrapper.java
@@ -1,0 +1,148 @@
+
+package com.jayway.jsonpath.internal.token;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Predicate;
+import com.jayway.jsonpath.spi.mapper.MappingException;
+
+/**
+ *
+ */
+public class StackElementWrapper implements Predicate.PredicateContext
+{
+    private Map cache;
+
+    private TokenStack stack;
+    private int idx;
+    private TokenStackElement elem;
+
+    public StackElementWrapper(TokenStack s, int i)
+    {
+        stack = s;
+        idx = i;
+        elem = stack.getStack().get(i);
+    }
+
+    public void reset(int i)
+    {
+        if (idx < i) {
+            // we are moving down the stack, so no cache removals are necessary
+            idx = i;
+            elem = stack.getStack().get(i);
+        } else if (idx > i) {
+            // we just popped up the stack, so we need to remove some things
+            // from the cache
+            TokenStackElement elem = null;
+            for (int j = i; j < idx; ++j) {
+                elem = stack.getStack().get(j);
+                popCache(this.elem);
+                //cache.remove(this.elem);
+            }
+            this.elem = elem;
+            idx = i;
+        } else {
+            TokenStackElement elem = stack.getStack().get(i);
+            if (this.elem != elem) {
+                popCache(this.elem); // just remove the previous thing
+                this.elem = elem;
+            }
+        }
+    }
+
+    protected Object unwrap(TokenStackElement elem)
+    {
+        Object o = cache.get(elem);
+
+        switch (elem.getType()) {
+        case ARRAY_TOKEN:
+        {
+            ArrayToken token = (ArrayToken)elem;
+            List l = (List)o;
+            if (null == l) {
+
+                l = new ArrayList(token.getIndex() + 1);
+                cache.put(elem, l);
+            }
+            ((ArrayList)l).ensureCapacity(token.getIndex() + 1);
+            //for (int i = 0; i < token.getIndex(); ++i) {
+            //  l.add(null);
+            //}
+            l.set(token.getIndex(), unwrap(token.getValue()));
+            return l;
+        }
+        case OBJECT_TOKEN:
+        {
+            ObjectToken token = (ObjectToken)elem;
+            Map m = (Map)o;
+            if (null == m) {
+
+                m = new HashMap();
+                cache.put(elem, m);
+            }
+            m.put(token.getKey(), unwrap(token.getValue()));
+            return m;
+        }
+        case STRING_TOKEN:
+        {
+            if (o != null) return o;
+            o = ((StringToken)elem).value;
+            //cache.put(elem, o);
+            return o;
+        }
+        case FLOAT_TOKEN:
+        {
+            if (o != null) return o;
+            o = new Float(((FloatToken)elem).value);
+            //cache.put(elem, o);
+            return o;
+        }
+        case INTEGER_TOKEN:
+        {
+            if (o != null) return o;
+            o = new Integer(((IntToken)elem).value);
+            //cache.put(elem, o);
+            return o;
+        }
+        default:
+        {
+            assert(false);
+        }
+        }
+
+        return null;
+    }
+
+    public void popCache(TokenStackElement elem)
+    {
+        cache.remove(elem);
+    }
+
+    public Object item()
+    {
+        return unwrap(elem);
+    }
+
+    public <T> T item(Class<T> clazz) throws MappingException
+    {
+        return configuration().mappingProvider().map(
+            item(), clazz, configuration());
+    }
+
+    public Object root()
+    {
+        return this; // ???? maybe unwrap the root element instead,
+        // but that's very very very expensive
+        // return unwrap(stack.getStack().get(0));
+    }
+
+    public Configuration configuration()
+    {
+        return stack.configuration();
+    }
+}
+

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/StringToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/StringToken.java
@@ -1,0 +1,33 @@
+
+package com.jayway.jsonpath.internal.token;
+
+/**
+ *
+ * @author Hunter Payne
+ **/
+public class StringToken implements TokenStackElement
+{
+    public String value;
+
+    public StringToken(String s)
+    {
+        value = s;
+    }
+
+    public TokenType getType()
+    {
+        return TokenType.STRING_TOKEN;
+    }
+
+    public TokenStackElement getValue()
+    {
+        return null;
+    }
+
+    public void setValue(TokenStackElement elem)
+    {
+        throw new RuntimeException();
+    }
+}
+
+// End StringToken.java

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/TokenStack.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/TokenStack.java
@@ -1,0 +1,217 @@
+
+package com.jayway.jsonpath.internal.token;
+
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.EvaluationCallback;
+import com.jayway.jsonpath.internal.Path;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+/**
+ *
+ * @author Hunter Payne
+ **/
+public class TokenStack
+{
+    protected static Logger log = Logger.getLogger("com.jayway.jsonpath");
+
+    protected Configuration conf;
+    protected Stack<TokenStackElement> elements;
+    protected List<Path> paths;
+    protected Map<TokenStackElement, Path> matchedPaths;
+
+    private TokenStackElement curr;
+
+    public TokenStack(Configuration conf)
+    {
+        this.conf = conf;
+        paths = new ArrayList<Path>();
+        matchedPaths = new HashMap<TokenStackElement, Path>();
+        elements = new Stack<TokenStackElement>();
+    }
+
+    public Stack<TokenStackElement> getStack()
+    {
+        return elements;
+    }
+
+    /**
+     * registers a path for which to fire results
+     */
+    public void registerPath(Path path)
+    {
+        paths.add(path);
+    }
+
+    // reads tokens and goes to first leaf
+    public void read(JsonParser parser, EvaluationCallback callback)
+    {
+        assert(callback != null);
+        try {
+            //boolean lookingForRow = true;
+            //TokenStackElement rowToken = null;
+            boolean needsPathCheck = false;
+            while (parser.nextToken() != null) {
+                boolean saveMatch = false;
+                switch (parser.getCurrentToken()) {
+                case START_ARRAY:
+                {
+                    if (curr != null) {
+                        TokenStackElement newElem = new ArrayToken();
+                        curr.setValue(newElem);
+                        curr = newElem;
+                    } else {
+                        curr = new ArrayToken();
+                    }
+                    saveMatch = true;
+                    needsPathCheck = true;
+                    elements.push(curr);
+                    break;
+                }
+                case END_ARRAY:
+                {
+                    Path match = matchedPaths.remove(curr);
+                    if (match != null) {
+                        callback.resultFoundExit(match);
+                    }
+                    elements.pop();
+                    if (elements.empty()) curr = null;
+                    else curr = elements.peek();
+                    saveMatch = true;
+                    needsPathCheck = true;
+
+                    break;
+                }
+                case VALUE_EMBEDDED_OBJECT:
+                case START_OBJECT:
+                {
+                    if (curr != null) {
+                        TokenStackElement newElem = new ObjectToken();
+                        curr.setValue(newElem);
+                        curr = newElem;
+                    } else {
+                        curr = new ObjectToken();
+                    }
+                    //if (!elements.empty())
+                    saveMatch = true;
+                    needsPathCheck = true;
+                    elements.push(curr);
+                    break;
+                }
+                case END_OBJECT:
+                {
+                    Path match = matchedPaths.remove(curr);
+                    if (match != null) {
+                        callback.resultFoundExit(match);
+                    }
+                    elements.pop();
+                    if (elements.empty()) curr = null;
+                    else curr = elements.peek();
+                    saveMatch = true;
+                    needsPathCheck = true;
+                    break;
+                }
+                case FIELD_NAME:
+                {
+                    assert(curr instanceof ObjectToken);
+                    ((ObjectToken)curr).key = parser.getText();
+                    break;
+                }
+                case VALUE_FALSE:
+                {
+                    StringToken newToken = new StringToken("FALSE");
+                    curr.setValue(newToken);
+                    needsPathCheck = true;
+                    break;
+                }
+                case VALUE_TRUE:
+                {
+                    StringToken newToken = new StringToken("TRUE");
+                    curr.setValue(newToken);
+                    needsPathCheck = true;
+                    break;
+                }
+                case VALUE_NUMBER_FLOAT:
+                {
+                    FloatToken newToken =
+                        new FloatToken((float)parser.getValueAsDouble());
+                    curr.setValue(newToken);
+                    needsPathCheck = true;
+                    break;
+                }
+                case VALUE_NUMBER_INT:
+                {
+                    IntToken newToken =
+                        new IntToken(parser.getValueAsInt());
+                    curr.setValue(newToken);
+                    needsPathCheck = true;
+                    break;
+                }
+                case VALUE_STRING:
+                {
+                    StringToken newToken =
+                        new StringToken(parser.getText());
+                    curr.setValue(newToken);
+                    needsPathCheck = true;
+                    break;
+                }
+                case VALUE_NULL:
+                {
+                    curr.setValue(null);
+                    needsPathCheck = true;
+                    break;
+                }
+                default:
+                    assert false;
+                }
+                // now check the paths for matches
+                if (needsPathCheck) {
+                    for (Path path : paths) {
+                        if (path.checkForMatch(this)) {
+                            if (saveMatch) {
+                                Path oldMatch = matchedPaths.get(curr);
+                                if (oldMatch != null) {
+                                    callback.resultFoundExit(oldMatch);
+                                }
+                                matchedPaths.put(curr, path);
+                                break;
+                            }
+                            callback.resultFound(path);
+                        }
+                    }
+                    needsPathCheck = false;
+                }
+            }
+        } catch (Exception e) {
+            //e.printStackTrace();
+            log.log(Level.INFO, e.getMessage(), e);
+        }
+        log.fine("finished read");
+    }
+
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Token Stack depth=");
+        sb.append(elements.size());
+        for (TokenStackElement elem : elements) {
+            sb.append(" ");
+            sb.append(elem.toString());
+        }
+        sb.append(" ");
+        sb.append(elements.peek().getValue());
+        return sb.toString();
+    }
+
+    public Configuration configuration()
+    {
+        return conf;
+    }
+}
+
+// End TokenStack.java
+

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/TokenStackElement.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/TokenStackElement.java
@@ -1,0 +1,17 @@
+
+package com.jayway.jsonpath.internal.token;
+
+/**
+ *
+ * @author Hunter Payne
+ **/
+public interface TokenStackElement
+{
+    public TokenType getType(); // otherwise its an object
+
+    public TokenStackElement getValue();
+
+    public void setValue(TokenStackElement elem);
+}
+
+// End TokenStackElement.java

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/TokenType.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/TokenType.java
@@ -1,0 +1,17 @@
+
+package com.jayway.jsonpath.internal.token;
+
+/**
+ *
+ * @author Hunter Payne
+ **/
+public enum TokenType
+{
+    ARRAY_TOKEN,
+    OBJECT_TOKEN,
+    STRING_TOKEN,
+    FLOAT_TOKEN,
+    INTEGER_TOKEN
+}
+
+// End TokenType.java

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/WildcardPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/WildcardPathToken.java
@@ -44,6 +44,14 @@ public class WildcardPathToken extends PathToken {
         }
     }
 
+    @Override
+    public boolean checkForMatch(TokenStack stack, int idx)
+    {
+        if (idx + 1 < stack.getStack().size()) {
+            return !isLeaf() && next().checkForMatch(stack, idx + 1);
+        }
+        return isLeaf();
+    }
 
     @Override
     boolean isTokenDefinite() {

--- a/json-path/src/test/java/com/jayway/jsonpath/FilterTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/FilterTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import com.jayway.jsonpath.internal.token.TokenStack;
 import static com.jayway.jsonpath.Criteria.where;
 import static com.jayway.jsonpath.Filter.filter;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -383,6 +384,11 @@ public class FilterTest extends BaseTest {
                 Integer i = (Integer) o;
 
                 return i == 1;
+            }
+
+            @Override
+            public boolean check(TokenStack stack, int idx) {
+                return false;
             }
         };
         assertThat(filter(where("string-key").eq("string").and("$").matches(p)).apply(createPredicateContext(json))).isEqualTo(true);

--- a/json-path/src/test/java/com/jayway/jsonpath/PredicateTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/PredicateTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Map;
 
+import com.jayway.jsonpath.internal.token.TokenStack;
 import static com.jayway.jsonpath.JsonPath.using;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,6 +19,11 @@ public class PredicateTest extends BaseTest {
             @Override
             public boolean apply(PredicateContext ctx) {
                 return ctx.item(Map.class).containsKey("isbn");
+            }
+
+            @Override
+            public boolean check(TokenStack stack, int idx) {
+                return false;
             }
         };
 

--- a/json-path/src/test/java/com/jayway/jsonpath/old/FilterTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/old/FilterTest.java
@@ -8,6 +8,7 @@ import com.jayway.jsonpath.InvalidCriteriaException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Predicate;
 import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.internal.token.TokenStack;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
@@ -346,6 +347,10 @@ public class FilterTest extends BaseTest {
                 }
                 return false;
             }
+            @Override
+            public boolean check(TokenStack stack, int idx) {
+                return false;
+            }
         };
 
         Filter rootChildFilter = filter(where("name").regex(Pattern.compile("rootChild_[A|B]")));
@@ -365,6 +370,10 @@ public class FilterTest extends BaseTest {
             @Override
             public boolean apply(PredicateContext ctx) {
                 return 1 == (Integer)ctx.item();
+            }
+            @Override
+            public boolean check(TokenStack stack, int idx) {
+                return false;
             }
         };
 


### PR DESCRIPTION
Adding a set of methods for high-performance streaming use.  For each Path implementation, we've added a method with the following signature: 

boolean checkForMatch(TokenStack stack);

Some extra classes that use the Jackson streaming API are also added to cut down on unnecessary object creation and allow for multiple paths to be evaluated at once and notified via a callback.  These classes are also for handling large JSON objects which can't be parsed into one tree.

Here is the callback API:

public interface EvaluationCallback {

    /**
     * Callback invoked when result is found
     * @param path -- the specific path that was triggered
     */
    void resultFound(Path path);

    /**
     * Callback invoked when the parser leaves the region in which the match
     * was found
     * @param path -- the specific path that was untriggered
     */
    void resultFoundExit(Path path);
}

and TokenStack has the following method:
void registerPath(Path path);

To use this streaming API:
1) create a TokenStack
2) register compiled paths with the TokenStack (via registerPath)
3) call read(JsonParser, EvaluationCallback) to launch an internal thread that will read from the parser until its out of bytes to parse
