### PR TITLE
Support for getting the length of an array.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ allprojects {
     ext.displayName = null
     ext.buildTimestamp = new Date().format('yyyy-MM-dd HH:mm:ss')
 
+    apply plugin: 'maven'
     group = 'com.jayway.jsonpath'
     version = '2.0.1' + (snapshotVersion ? "-SNAPSHOT" : "")
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/PathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/PathToken.java
@@ -128,6 +128,17 @@ public abstract class PathToken {
         }
     }
 
+    void handleArrayLength(String currentPath, Object model, EvaluationContextImpl ctx) {
+        String evalPath = currentPath + ".length";
+        PathRef pathRef = ctx.forUpdate() ? PathRef.create(model, "length") : PathRef.NO_OP;
+        Object evalHit = ctx.jsonProvider().length(model);
+        if (isLeaf()) {
+            ctx.addResult(evalPath, pathRef, evalHit);
+        } else {
+            next().evaluate(evalPath, pathRef, evalHit, ctx);
+        }
+    }
+
     PathToken prev(){
         return prev;
     }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/PropertyPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/PropertyPathToken.java
@@ -38,6 +38,11 @@ public class PropertyPathToken extends PathToken {
     @Override
     public void evaluate(String currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
         if (!ctx.jsonProvider().isMap(model)) {
+            // Special case handling of the 'length' property of arrays.
+            if (isLeaf() && ctx.jsonProvider().isArray(model) && properties.size() == 1 && properties.get(0).equals("length")) {
+                handleArrayLength(currentPath, model, ctx);
+                return;
+            }
             throw new PathNotFoundException("Property " + getPathFragment() + " not found in path " + currentPath);
         }
 

--- a/json-path/src/test/java/com/jayway/jsonpath/JsonProviderTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JsonProviderTest.java
@@ -75,6 +75,13 @@ public class JsonProviderTest extends BaseTest {
         assertThat(using(GSON_CONFIGURATION).parse(JSON).read("$", typeRef)).extracting("foo").containsExactly("foo0", "foo1", "foo2");
     }
 
+    @Test
+    public void length_of_array() {
+        assertThat(using(JACKSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$.store.book.length", Integer.class)).isEqualTo(4);
+        assertThat(using(JACKSON_JSON_NODE_CONFIGURATION).parse(JSON_DOCUMENT).read("$.store.book.length", Integer.class)).isEqualTo(4);
+        assertThat(using(JSON_SMART_CONFIGURATION).parse(JSON_DOCUMENT).read("$.store.book.length", Integer.class)).isEqualTo(4);
+        assertThat(using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$.store.book.length", Integer.class)).isEqualTo(4);
+    }
 
     public static class FooBarBaz<T> {
         public T gen;


### PR DESCRIPTION
This commit allows you to use ".length" in a JSONPath to get the length of an array. This is supported by the Goessner implementation (according to the JsonPath Evaluator), but seems to be lacking in the Jayway implementation. For example, "$.store.book.length" returns 4.

I'm new to the JsonPath code so there is probably a better way of doing this. Feel free to make suggestions for improvement or alternate implementation. 