### PR TITLE
bug(Configuration.java) configuration builder gets defaults when not needed

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/Configuration.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Configuration.java
@@ -230,12 +230,14 @@ public class Configuration {
         }
 
         public Configuration build() {
-            Defaults defaults = getEffectiveDefaults();
-            if (jsonProvider == null) {
-                jsonProvider = defaults.jsonProvider();
-            }
-            if(mappingProvider == null){
-                mappingProvider = defaults.mappingProvider();
+            if(null==jsonProvider || null== mappingProvider) {
+                Defaults defaults = getEffectiveDefaults();
+                if (jsonProvider == null) {
+                    jsonProvider = defaults.jsonProvider();
+                }
+                if (mappingProvider == null) {
+                    mappingProvider = defaults.mappingProvider();
+                }
             }
             return new Configuration(jsonProvider, mappingProvider, options, evaluationListener);
         }


### PR DESCRIPTION
- Configuration builder forces a dependency on json-smart when defaults are gotten, even when they are not needed.

fixes #121