### PR TITLE
Remove slf4j

### DIFF
--- a/json-path-web-test/build.gradle
+++ b/json-path-web-test/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     compile project(':json-path')
     compile 'commons-io:commons-io:2.4'
     compile libs.jacksonDatabind
+    compile libs.slf4jApi
     compile 'io.fastjson:boon:0.33'
     compile 'com.nebhale.jsonpath:jsonpath:1.2'
     compile 'io.gatling:jsonpath_2.10:0.6.4'

--- a/json-path/build.gradle
+++ b/json-path/build.gradle
@@ -15,7 +15,6 @@ jar {
 
 dependencies {
     compile libs.jsonSmart
-    compile libs.slf4jApi
     compile libs.jacksonDatabind, optional
     compile libs.gson, optional
 

--- a/json-path/src/main/java/com/jayway/jsonpath/Configuration.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Configuration.java
@@ -18,9 +18,6 @@ import com.jayway.jsonpath.internal.DefaultsImpl;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import com.jayway.jsonpath.spi.mapper.MappingProvider;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,8 +32,6 @@ import static java.util.Arrays.asList;
  * Immutable configuration object
  */
 public class Configuration {
-
-    private static final Logger logger = LoggerFactory.getLogger(Configuration.class);
 
     private static Defaults DEFAULTS = null;
 

--- a/json-path/src/main/java/com/jayway/jsonpath/Criteria.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Criteria.java
@@ -17,8 +17,6 @@ package com.jayway.jsonpath;
 import com.jayway.jsonpath.internal.Path;
 import com.jayway.jsonpath.internal.PathCompiler;
 import com.jayway.jsonpath.internal.token.PredicateContextImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -36,8 +34,6 @@ import static com.jayway.jsonpath.internal.Utils.notNull;
  */
 @SuppressWarnings("unchecked")
 public class Criteria implements Predicate {
-
-    private static final Logger logger = LoggerFactory.getLogger(Criteria.class);
 
     private static final String[] OPERATORS = {
             CriteriaType.EQ.toString(),
@@ -60,7 +56,6 @@ public class Criteria implements Predicate {
             @Override
             boolean eval(Object expected, Object model, PredicateContext ctx) {
                 boolean res = (0 == safeCompare(expected, model));
-                if (logger.isDebugEnabled()) logger.debug("[{}] {} [{}] => {}", model, name(), expected, res);
                 return res;
             }
 
@@ -73,7 +68,6 @@ public class Criteria implements Predicate {
             @Override
             boolean eval(Object expected, Object model, PredicateContext ctx) {
                 boolean res = (0 != safeCompare(expected, model));
-                if (logger.isDebugEnabled()) logger.debug("[{}] {} [{}] => {}", model, name(), expected, res);
                 return res;
             }
 
@@ -89,7 +83,6 @@ public class Criteria implements Predicate {
                     return false;
                 }
                 boolean res = (0 > safeCompare(expected, model));
-                if (logger.isDebugEnabled()) logger.debug("[{}] {} [{}] => {}", model, name(), expected, res);
                 return res;
             }
 
@@ -105,7 +98,6 @@ public class Criteria implements Predicate {
                     return false;
                 }
                 boolean res = (0 >= safeCompare(expected, model));
-                if (logger.isDebugEnabled()) logger.debug("[{}] {} [{}] => {}", model, name(), expected, res);
                 return res;
             }
 
@@ -121,7 +113,6 @@ public class Criteria implements Predicate {
                     return false;
                 }
                 boolean res = (0 < safeCompare(expected, model));
-                if (logger.isDebugEnabled()) logger.debug("[{}] {} [{}] => {}", model, name(), expected, res);
                 return res;
             }
 
@@ -137,7 +128,6 @@ public class Criteria implements Predicate {
                     return false;
                 }
                 boolean res = (0 <= safeCompare(expected, model));
-                if (logger.isDebugEnabled()) logger.debug("[{}] {} [{}] => {}", model, name(), expected, res);
                 return res;
             }
 
@@ -157,7 +147,6 @@ public class Criteria implements Predicate {
                         break;
                     }
                 }
-                if (logger.isDebugEnabled()) logger.debug("[{}] {} [{}] => {}", model, name(), join(", ", exps), res);
                 return res;
             }
         },
@@ -166,7 +155,6 @@ public class Criteria implements Predicate {
             boolean eval(Object expected, Object model, PredicateContext ctx) {
                 Collection nexps = (Collection) expected;
                 boolean res = !nexps.contains(model);
-                if (logger.isDebugEnabled()) logger.debug("[{}] {} [{}] => {}", model, name(), join(", ", nexps), res);
                 return res;
             }
         },
@@ -188,7 +176,6 @@ public class Criteria implements Predicate {
                         res = ((String) model).contains((String)expected);
                     }
                 }
-                if (logger.isDebugEnabled()) logger.debug("[{}] {} [{}] => {}", model, name(), expected, res);
                 return res;
             }
         },
@@ -211,11 +198,8 @@ public class Criteria implements Predicate {
                             break;
                         }
                     }
-                    if (logger.isDebugEnabled())
-                        logger.debug("[{}] {} [{}] => {}", join(", ", ctx.configuration().jsonProvider().toIterable(model)), name(), join(", ", exps), res);
                 } else {
                     res = false;
-                    if (logger.isDebugEnabled()) logger.debug("[{}] {} [{}] => {}", "<NOT AN ARRAY>", name(), join(", ", exps), res);
                 }
                 return res;
             }
@@ -228,15 +212,11 @@ public class Criteria implements Predicate {
                 if (ctx.configuration().jsonProvider().isArray(model)) {
                     int length = ctx.configuration().jsonProvider().length(model);
                     res = (length == size);
-                    if (logger.isDebugEnabled()) logger.debug("Array with size {} {} {} => {}", length, name(), size, res);
                 } else if (model instanceof String) {
                     int length = ((String) model).length();
                     res = length == size;
-                    if (logger.isDebugEnabled()) logger.debug("String with length {} {} {} => {}", length, name(), size, res);
                 } else {
                     res = false;
-                    if (logger.isDebugEnabled())
-                        logger.debug("{} {} {} => {}", model == null ? "null" : model.getClass().getName(), name(), size, res);
                 }
                 return res;
             }
@@ -275,8 +255,6 @@ public class Criteria implements Predicate {
                 if (target != null) {
                     res = pattern.matcher(target.toString()).matches();
                 }
-                if (logger.isDebugEnabled())
-                    logger.debug("[{}] {} [{}] => {}", model == null ? "null" : model.toString(), name(), expected == null ? "null" : expected.toString(), res);
                 return res;
             }
 
@@ -301,11 +279,9 @@ public class Criteria implements Predicate {
                     if (ctx.configuration().jsonProvider().isArray(model)) {
                         int len = ctx.configuration().jsonProvider().length(model);
                         res = (0 != len);
-                        if (logger.isDebugEnabled()) logger.debug("array length = {} {} => {}", len, name(), res);
                     } else if (model instanceof String) {
                         int len = ((String) model).length();
                         res = (0 != len);
-                        if (logger.isDebugEnabled()) logger.debug("string length = {} {} => {}", len, name(), res);
                     }
                 }
                 return res;
@@ -842,7 +818,6 @@ public class Criteria implements Predicate {
             Boolean a = (Boolean) right;
             return e.compareTo(a);
         } else {
-            logger.debug("Can not compare a {} with a {}", left.getClass().getName(), right.getClass().getName());
             throw new ValueCompareException();
         }
     }

--- a/json-path/src/main/java/com/jayway/jsonpath/Filter.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Filter.java
@@ -15,8 +15,6 @@
 package com.jayway.jsonpath;
 
 import com.jayway.jsonpath.internal.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,7 +28,6 @@ import static java.util.Arrays.asList;
  */
 public abstract class Filter implements Predicate {
 
-    private static final Logger logger = LoggerFactory.getLogger(Filter.class);
     private static final Pattern OPERATOR_SPLIT = Pattern.compile("((?<=&&|\\|\\|)|(?=&&|\\|\\|))");
     private static final String AND = "&&";
     private static final String OR = "||";
@@ -192,7 +189,6 @@ public abstract class Filter implements Predicate {
             throw new InvalidPathException("Invalid operators " + filter);
         }
 
-        if(logger.isDebugEnabled()) logger.debug("Parsed filter: " + root.toString());
         return root;
     }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/InvalidJsonException.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/InvalidJsonException.java
@@ -17,18 +17,42 @@ package com.jayway.jsonpath;
 @SuppressWarnings("serial")
 public class InvalidJsonException extends JsonPathException {
 
+    /**
+     * Problematic JSON if available.
+     */
+    private final String json;
+    
     public InvalidJsonException() {
+        json = null;
     }
 
     public InvalidJsonException(String message) {
         super(message);
+        json = null;
     }
 
     public InvalidJsonException(String message, Throwable cause) {
         super(message, cause);
+        json = null;
     }
 
     public InvalidJsonException(Throwable cause) {
         super(cause);
+        json = null;
+    }
+    
+    /**
+     * Rethrow the exception with the problematic JSON captured.
+     */
+    public InvalidJsonException(final Throwable cause, final String json) {
+        super(cause);
+        this.json = json;
+    }
+    
+    /**
+     * @return the problematic JSON if available.
+     */
+    public String getJson() {
+        return json;
     }
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/CompiledPath.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/CompiledPath.java
@@ -17,19 +17,12 @@ package com.jayway.jsonpath.internal;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.internal.token.EvaluationContextImpl;
 import com.jayway.jsonpath.internal.token.PathToken;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class CompiledPath implements Path {
-
-    private static final Logger logger = LoggerFactory.getLogger(CompiledPath.class);
 
     private final PathToken root;
 
     private final boolean isRootPath;
-
-
-
 
     public CompiledPath(PathToken root, boolean isRootPath) {
         this.root = root;
@@ -43,10 +36,6 @@ public class CompiledPath implements Path {
 
     @Override
     public EvaluationContext evaluate(Object document, Object rootDocument, Configuration configuration, boolean forUpdate) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Evaluating path: {}", toString());
-        }
-
         EvaluationContextImpl ctx = new EvaluationContextImpl(this, rootDocument, configuration, forUpdate);
         try {
             PathRef op = ctx.forUpdate() ?  PathRef.createRoot(rootDocument) : PathRef.NO_OP;

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonFormatter.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonFormatter.java
@@ -14,12 +14,7 @@
  */
 package com.jayway.jsonpath.internal;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class JsonFormatter {
-
-    private static final Logger logger = LoggerFactory.getLogger(JsonFormatter.class);
 
     private static final String INDENT = "   ";
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonReader.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonReader.java
@@ -23,8 +23,6 @@ import com.jayway.jsonpath.ParseContext;
 import com.jayway.jsonpath.Predicate;
 import com.jayway.jsonpath.ReadContext;
 import com.jayway.jsonpath.TypeRef;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -37,8 +35,6 @@ import static com.jayway.jsonpath.internal.Utils.notEmpty;
 import static com.jayway.jsonpath.internal.Utils.notNull;
 
 public class JsonReader implements ParseContext, DocumentContext {
-
-    private static final Logger logger = LoggerFactory.getLogger(JsonReader.class);
 
     private final Configuration configuration;
     private Object json;
@@ -186,11 +182,6 @@ public class JsonReader implements ParseContext, DocumentContext {
     @Override
     public DocumentContext set(JsonPath path, Object newValue){
         List<String> modified = path.set(json, newValue, configuration.addOptions(Option.AS_PATH_LIST));
-        if(logger.isDebugEnabled()){
-            for (String p : modified) {
-                logger.debug("Set path {} new value {}", p, newValue);
-            }
-        }
         return this;
     }
 
@@ -202,11 +193,6 @@ public class JsonReader implements ParseContext, DocumentContext {
     @Override
     public DocumentContext delete(JsonPath path) {
         List<String> modified = path.delete(json, configuration.addOptions(Option.AS_PATH_LIST));
-        if(logger.isDebugEnabled()){
-            for (String p : modified) {
-                logger.debug("Delete path {}");
-            }
-        }
         return this;
     }
 
@@ -218,11 +204,6 @@ public class JsonReader implements ParseContext, DocumentContext {
     @Override
     public DocumentContext add(JsonPath path, Object value){
         List<String> modified =  path.add(json, value, configuration.addOptions(Option.AS_PATH_LIST));
-        if(logger.isDebugEnabled()){
-            for (String p : modified) {
-                logger.debug("Add path {} new value {}", p, value);
-            }
-        }
         return this;
     }
 
@@ -234,11 +215,6 @@ public class JsonReader implements ParseContext, DocumentContext {
     @Override
     public DocumentContext put(JsonPath path, String key, Object value){
         List<String> modified = path.put(json, key, value, configuration.addOptions(Option.AS_PATH_LIST));
-        if(logger.isDebugEnabled()){
-            for (String p : modified) {
-                logger.debug("Put path {} key {} value {}", p, key, value);
-            }
-        }
         return this;
     }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/PathCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/PathCompiler.java
@@ -24,8 +24,6 @@ import com.jayway.jsonpath.internal.token.PropertyPathToken;
 import com.jayway.jsonpath.internal.token.RootPathToken;
 import com.jayway.jsonpath.internal.token.ScanPathToken;
 import com.jayway.jsonpath.internal.token.WildcardPathToken;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -36,8 +34,6 @@ import static com.jayway.jsonpath.internal.Utils.notEmpty;
 import static java.util.Arrays.asList;
 
 public class PathCompiler {
-
-    private static final Logger logger = LoggerFactory.getLogger(PathCompiler.class);
 
     private static final String PROPERTY_OPEN = "['";
     private static final String PROPERTY_CLOSE = "']";
@@ -81,7 +77,6 @@ public class PathCompiler {
             String cacheKey = Utils.concat(trimmedPath, Boolean.toString(isRootPath), filterList.toString());
             Path p = cache.get(cacheKey);
             if (p != null) {
-                if (logger.isDebugEnabled()) logger.debug("Using cached path: {}", cacheKey);
                 return p;
             }
 
@@ -475,16 +470,6 @@ public class PathCompiler {
             }
             singleIndex = (numbers.size() == 1) && !sliceTo && !sliceFrom && !contextSize;
 
-            if (logger.isTraceEnabled()) {
-                logger.debug("numbers are                : {}", numbers.toString());
-                logger.debug("sequence is singleNumber   : {}", singleIndex);
-                logger.debug("sequence is numberSequence : {}", indexSequence);
-                logger.debug("sequence is sliceFrom      : {}", sliceFrom);
-                logger.debug("sequence is sliceTo        : {}", sliceTo);
-                logger.debug("sequence is sliceBetween   : {}", sliceBetween);
-                logger.debug("sequence is contextFetch   : {}", contextSize);
-                logger.debug("---------------------------------------------");
-            }
             ArrayPathToken.Operation operation = null;
 
             if (singleIndex) operation = ArrayPathToken.Operation.SINGLE_INDEX;

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/ArrayPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/ArrayPathToken.java
@@ -18,8 +18,6 @@ import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.internal.PathRef;
 import com.jayway.jsonpath.internal.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -29,8 +27,6 @@ import static java.lang.String.format;
  *
  */
 public class ArrayPathToken extends PathToken {
-
-    private static final Logger logger = LoggerFactory.getLogger(ArrayPathToken.class);
 
     public static enum Operation {
         CONTEXT_SIZE,
@@ -94,8 +90,6 @@ public class ArrayPathToken extends PathToken {
                     }
                     from = Math.max(0, from);
 
-                    logger.debug("Slice from index on array with length: {}. From index: {} to: {}. Input: {}", length, from, length - 1, toString());
-
                     if (length == 0 || from >= length) {
                         return;
                     }
@@ -113,8 +107,6 @@ public class ArrayPathToken extends PathToken {
                         to = length + to;
                     }
                     to = Math.min(length, to);
-
-                    logger.debug("Slice to index on array with length: {}. From index: 0 to: {}. Input: {}", length, to, toString());
 
                     if (length == 0) {
                         return;
@@ -134,8 +126,6 @@ public class ArrayPathToken extends PathToken {
                     if (from >= to || length == 0) {
                         return;
                     }
-
-                    logger.debug("Slice between indexes on array with length: {}. From index: {} to: {}. Input: {}", length, from, to, toString());
 
                     for (int i = from; i < to; i++) {
                         handleArrayIndex(i, currentPath, model, ctx);

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/EvaluationContextImpl.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/EvaluationContextImpl.java
@@ -23,8 +23,6 @@ import com.jayway.jsonpath.internal.EvaluationContext;
 import com.jayway.jsonpath.internal.Path;
 import com.jayway.jsonpath.internal.PathRef;
 import com.jayway.jsonpath.spi.json.JsonProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -39,8 +37,6 @@ import static com.jayway.jsonpath.internal.Utils.notNull;
  *
  */
 public class EvaluationContextImpl implements EvaluationContext {
-
-    private static final Logger logger = LoggerFactory.getLogger(EvaluationContextImpl.class);
 
     private final Configuration configuration;
     private final Object valueResult;

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/PredicateContextImpl.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/PredicateContextImpl.java
@@ -18,14 +18,10 @@ import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.Predicate;
 import com.jayway.jsonpath.internal.Path;
 import com.jayway.jsonpath.spi.mapper.MappingException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 
 public class PredicateContextImpl implements Predicate.PredicateContext {
-
-    private static final Logger logger = LoggerFactory.getLogger(PredicateContextImpl.class);
 
     private final Object contextDocument;
     private final Object rootDocument;
@@ -43,7 +39,6 @@ public class PredicateContextImpl implements Predicate.PredicateContext {
         Object result;
         if(path.isRootPath()){
             if(documentPathCache.containsKey(path)){
-                logger.debug("Using cached result for root path: " + path.toString());
                 result = documentPathCache.get(path);
             } else {
                 result = path.evaluate(rootDocument, rootDocument, configuration).getValue();

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/RootPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/RootPathToken.java
@@ -15,15 +15,11 @@
 package com.jayway.jsonpath.internal.token;
 
 import com.jayway.jsonpath.internal.PathRef;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
 public class RootPathToken extends PathToken {
-
-    private static final Logger logger = LoggerFactory.getLogger(RootPathToken.class);
 
     private PathToken tail;
     private int tokenCount;

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/AbstractJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/AbstractJsonProvider.java
@@ -15,17 +15,12 @@
 package com.jayway.jsonpath.spi.json;
 
 import com.jayway.jsonpath.JsonPathException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 public abstract class AbstractJsonProvider implements JsonProvider {
-
-    private static final Logger logger = LoggerFactory.getLogger(AbstractJsonProvider.class);
-
 
     /**
      * checks if object is an array

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/GsonJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/GsonJsonProvider.java
@@ -24,8 +24,6 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.internal.LazilyParsedNumber;
 import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPathException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -37,8 +35,6 @@ import java.util.List;
 import java.util.Map;
 
 public class GsonJsonProvider extends AbstractJsonProvider {
-
-    private static final Logger logger = LoggerFactory.getLogger(GsonJsonProvider.class);
 
     private static final JsonParser parser = new JsonParser();
     private static final Gson gson = new GsonBuilder().create();

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonNodeJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonNodeJsonProvider.java
@@ -8,8 +8,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPathException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,8 +18,6 @@ import java.util.Iterator;
 import java.util.List;
 
 public class JacksonJsonNodeJsonProvider extends AbstractJsonProvider {
-
-    private static final Logger logger = LoggerFactory.getLogger(JacksonJsonProvider.class);
 
     private static final ObjectMapper defaultObjectMapper = new ObjectMapper();
 
@@ -52,8 +48,7 @@ public class JacksonJsonNodeJsonProvider extends AbstractJsonProvider {
         try {
             return objectMapper.readTree(json);
         } catch (IOException e) {
-            logger.debug("Invalid JSON: \n" + json);
-            throw new InvalidJsonException(e);
+            throw new InvalidJsonException(e, json);
         }
     }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonProvider.java
@@ -18,8 +18,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.jayway.jsonpath.InvalidJsonException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,8 +28,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class JacksonJsonProvider extends AbstractJsonProvider {
-
-    private static final Logger logger = LoggerFactory.getLogger(JacksonJsonProvider.class);
 
     private static final ObjectMapper defaultObjectMapper = new ObjectMapper();
     private static final ObjectReader defaultObjectReader = defaultObjectMapper.reader().withType(Object.class);
@@ -73,8 +69,7 @@ public class JacksonJsonProvider extends AbstractJsonProvider {
         try {
             return objectReader.readValue(json);
         } catch (IOException e) {
-            logger.debug("Invalid JSON: \n" + json);
-            throw new InvalidJsonException(e);
+            throw new InvalidJsonException(e, json);
         }
     }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/mapper/GsonMappingProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/mapper/GsonMappingProvider.java
@@ -20,14 +20,10 @@ import com.google.gson.reflect.TypeToken;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.TypeRef;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Callable;
 
 public class GsonMappingProvider implements MappingProvider {
-
-    private static final Logger logger = LoggerFactory.getLogger(GsonMappingProvider.class);
 
     private final Callable<Gson> factory;
 
@@ -55,7 +51,6 @@ public class GsonMappingProvider implements MappingProvider {
                 }
             };
         } catch (ClassNotFoundException e) {
-            logger.error("Gson not found on class path. No converters configured.");
             throw new JsonPathException("Gson not found on path", e);
         }
     }

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/mapper/JsonSmartMappingProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/mapper/JsonSmartMappingProvider.java
@@ -19,8 +19,6 @@ import com.jayway.jsonpath.TypeRef;
 import net.minidev.json.JSONValue;
 import net.minidev.json.writer.JsonReader;
 import net.minidev.json.writer.JsonReaderI;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.text.DateFormat;
@@ -29,8 +27,6 @@ import java.util.Date;
 import java.util.concurrent.Callable;
 
 public class JsonSmartMappingProvider implements MappingProvider {
-
-    private static final Logger logger = LoggerFactory.getLogger(JsonSmartMappingProvider.class);
 
     private static JsonReader DEFAULT = new JsonReader();
 


### PR DESCRIPTION
This reduces the [dependency convergence][1] problems with slf4j when using json-path in other projects.

All the logging was removed in commit 0c61f5b.  Another approach could be to use the `java.util.logging` which will not cause any [dependency convergence][1] issues.

[1]: https://maven.apache.org/enforcer/enforcer-rules/dependencyConvergence.html