### PR TITLE
Only call getEffectiveDefaults when needed

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/Configuration.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Configuration.java
@@ -18,9 +18,6 @@ import com.jayway.jsonpath.internal.DefaultsImpl;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import com.jayway.jsonpath.spi.mapper.MappingProvider;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,8 +32,6 @@ import static java.util.Arrays.asList;
  * Immutable configuration object
  */
 public class Configuration {
-
-    private static final Logger logger = LoggerFactory.getLogger(Configuration.class);
 
     private static Defaults DEFAULTS = null;
 
@@ -230,12 +225,14 @@ public class Configuration {
         }
 
         public Configuration build() {
-            Defaults defaults = getEffectiveDefaults();
-            if (jsonProvider == null) {
-                jsonProvider = defaults.jsonProvider();
-            }
-            if(mappingProvider == null){
-                mappingProvider = defaults.mappingProvider();
+            if (jsonProvider == null || mappingProvider == null) {
+                final Defaults defaults = getEffectiveDefaults();
+                if (jsonProvider == null) {
+                    jsonProvider = defaults.jsonProvider();
+                }
+                if (mappingProvider == null){
+                    mappingProvider = defaults.mappingProvider();
+                }
             }
             return new Configuration(jsonProvider, mappingProvider, options, evaluationListener);
         }


### PR DESCRIPTION
The call to `getEffectiveDefaults` will make `json-smart` dependency
required for processing.  By removing the call when not needed
`json-smart` can be safely excluded.

In addition the logger was removed since it was not being used.