### PR TITLE
Externalize cache to CacheProvider spi #94

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/Configuration.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Configuration.java
@@ -15,6 +15,8 @@
 package com.jayway.jsonpath;
 
 import com.jayway.jsonpath.internal.DefaultsImpl;
+import com.jayway.jsonpath.spi.cache.CacheProvider;
+import com.jayway.jsonpath.spi.cache.DefaultCache;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import com.jayway.jsonpath.spi.mapper.MappingProvider;
 
@@ -55,14 +57,16 @@ public class Configuration {
     private final MappingProvider mappingProvider;
     private final Set<Option> options;
     private final Collection<EvaluationListener> evaluationListeners;
+    private final CacheProvider cacheProvider;
 
-    private Configuration(JsonProvider jsonProvider, MappingProvider mappingProvider, EnumSet<Option> options, Collection<EvaluationListener> evaluationListeners) {
+    private Configuration(JsonProvider jsonProvider, MappingProvider mappingProvider, CacheProvider cacheProvider, EnumSet<Option> options, Collection<EvaluationListener> evaluationListeners) {
         notNull(jsonProvider, "jsonProvider can not be null");
         notNull(mappingProvider, "mappingProvider can not be null");
         notNull(options, "setOptions can not be null");
         notNull(evaluationListeners, "evaluationListeners can not be null");
         this.jsonProvider = jsonProvider;
         this.mappingProvider = mappingProvider;
+        this.cacheProvider = cacheProvider;
         this.options = Collections.unmodifiableSet(options);
         this.evaluationListeners = Collections.unmodifiableCollection(evaluationListeners);
     }
@@ -125,6 +129,23 @@ public class Configuration {
      */
     public MappingProvider mappingProvider() {
         return mappingProvider;
+    }
+    
+    /**
+     * Creates a new Configuration based on the given {@link com.jayway.jsonpath.spi.cache.CacheProvider}
+     * @param newCacheProvider cache provider to use in new configuration
+     * @return a new configuration
+     */
+    public Configuration CacheProvider(CacheProvider newCacheProvider) {
+        return Configuration.builder().jsonProvider(jsonProvider).mappingProvider(mappingProvider).cacheProvider(newCacheProvider).options(options).evaluationListener(evaluationListeners).build();
+    }
+
+    /**
+     * Returns {@link com.jayway.jsonpath.spi.cache.CacheProvider} used by this configuration
+     * @return cacheProvider used
+     */
+    public CacheProvider CacheProvider() {
+        return cacheProvider;
     }
 
     /**
@@ -189,6 +210,7 @@ public class Configuration {
 
         private JsonProvider jsonProvider;
         private MappingProvider mappingProvider;
+        private CacheProvider cacheProvider = new DefaultCache(200);
         private EnumSet<Option> options = EnumSet.noneOf(Option.class);
         private Collection<EvaluationListener> evaluationListener = new ArrayList<EvaluationListener>();
 
@@ -199,6 +221,11 @@ public class Configuration {
 
         public ConfigurationBuilder mappingProvider(MappingProvider provider) {
             this.mappingProvider = provider;
+            return this;
+        }
+        
+        public ConfigurationBuilder cacheProvider(CacheProvider provider) {
+            this.cacheProvider = provider;
             return this;
         }
 
@@ -233,8 +260,11 @@ public class Configuration {
                 if (mappingProvider == null){
                     mappingProvider = defaults.mappingProvider();
                 }
+                if (cacheProvider == null){
+                    cacheProvider = defaults.cacheProvider();
+                }
             }
-            return new Configuration(jsonProvider, mappingProvider, options, evaluationListener);
+            return new Configuration(jsonProvider, mappingProvider, cacheProvider, options, evaluationListener);
         }
     }
 
@@ -257,6 +287,13 @@ public class Configuration {
          * @return default mapping provider
          */
         MappingProvider mappingProvider();
+        
+        /**
+         * Returns the default {@link com.jayway.jsonpath.spi.cache.CacheProvider}
+         *
+         * @return default cache provider
+         */
+        CacheProvider cacheProvider();
 
     }
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/DefaultsImpl.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/DefaultsImpl.java
@@ -5,6 +5,8 @@ import java.util.Set;
 
 import com.jayway.jsonpath.Configuration.Defaults;
 import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.cache.DefaultCache;
+import com.jayway.jsonpath.spi.cache.CacheProvider;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JsonSmartMappingProvider;
@@ -15,6 +17,8 @@ public final class DefaultsImpl implements Defaults {
   public static final DefaultsImpl INSTANCE = new DefaultsImpl();
 
   private final MappingProvider mappingProvider = new JsonSmartMappingProvider();
+  
+  private final CacheProvider cacheProvider = new DefaultCache(200);
 
   @Override
   public JsonProvider jsonProvider() {
@@ -32,6 +36,11 @@ public final class DefaultsImpl implements Defaults {
   }
 
   private DefaultsImpl() {
-  };
+  }
+
+	@Override
+	public CacheProvider cacheProvider() {
+		return cacheProvider;
+	};
 
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonReader.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonReader.java
@@ -23,6 +23,8 @@ import com.jayway.jsonpath.ParseContext;
 import com.jayway.jsonpath.Predicate;
 import com.jayway.jsonpath.ReadContext;
 import com.jayway.jsonpath.TypeRef;
+import com.jayway.jsonpath.spi.cache.CacheProvider;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -132,11 +134,14 @@ public class JsonReader implements ParseContext, DocumentContext {
     @Override
     public <T> T read(String path, Predicate... filters) {
         notEmpty(path, "path can not be null or empty");
-        JsonPath cached = configuration.CacheProvider().get(path);
-        if(cached != null){
-        	return read(cached);
+        CacheProvider cache = configuration.CacheProvider();
+        JsonPath jsonPath = cache.get(path);
+        if(jsonPath != null){
+        	return read(jsonPath);
         }else {
-        	return read(compile(path, filters));
+        	jsonPath = compile(path, filters);
+        	cache.put(path, jsonPath);
+        	return read(jsonPath);
         }
 
     }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonReader.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonReader.java
@@ -147,7 +147,7 @@ public class JsonReader implements ParseContext, DocumentContext {
         	return read(jsonPath);
         }else {
         	jsonPath = compile(path, filters);
-        	cache.put(path, jsonPath);
+        	cache.put(cacheKey, jsonPath);
         	return read(jsonPath);
         }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonReader.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonReader.java
@@ -132,7 +132,13 @@ public class JsonReader implements ParseContext, DocumentContext {
     @Override
     public <T> T read(String path, Predicate... filters) {
         notEmpty(path, "path can not be null or empty");
-        return read(compile(path, filters));
+        JsonPath cached = configuration.CacheProvider().get(path);
+        if(cached != null){
+        	return read(cached);
+        }else {
+        	return read(compile(path, filters));
+        }
+
     }
 
     @Override

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonReader.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonReader.java
@@ -32,11 +32,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.LinkedList;
 import java.util.List;
 
 import static com.jayway.jsonpath.JsonPath.compile;
 import static com.jayway.jsonpath.internal.Utils.notEmpty;
 import static com.jayway.jsonpath.internal.Utils.notNull;
+import static java.util.Arrays.asList;
 
 public class JsonReader implements ParseContext, DocumentContext {
 
@@ -135,7 +137,12 @@ public class JsonReader implements ParseContext, DocumentContext {
     public <T> T read(String path, Predicate... filters) {
         notEmpty(path, "path can not be null or empty");
         CacheProvider cache = configuration.CacheProvider();
-        JsonPath jsonPath = cache.get(path);
+        
+        path = path.trim();
+        LinkedList filterStack = new LinkedList<Predicate>(asList(filters));
+        String cacheKey = Utils.concat(path, filterStack.toString());
+        
+        JsonPath jsonPath = cache.get(cacheKey);
         if(jsonPath != null){
         	return read(jsonPath);
         }else {

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/PathCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/PathCompiler.java
@@ -66,12 +66,12 @@ public class PathCompiler {
                 fail("Path must not end wid a scan operation '..'");
             }
             LinkedList filterStack = new LinkedList<Predicate>(asList(filters));
-            String cacheKey = Utils.concat(path, filterStack.toString());
-            Path p = cache.get(cacheKey);
-            if (p == null) {
-                p = new PathCompiler(path.trim(), filterStack).compile();
-                cache.put(cacheKey, p);
-            }
+//            String cacheKey = Utils.concat(path, filterStack.toString());
+//            Path p = cache.get(cacheKey);
+//            if (p == null) {
+            Path p = new PathCompiler(path.trim(), filterStack).compile();
+//                cache.put(cacheKey, p);
+//            }
             return p;
         } catch (Exception e) {
             InvalidPathException ipe;

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/cache/CacheProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/cache/CacheProvider.java
@@ -1,0 +1,23 @@
+package com.jayway.jsonpath.spi.cache;
+
+import com.jayway.jsonpath.InvalidJsonException;
+import com.jayway.jsonpath.JsonPath;
+
+public interface CacheProvider {
+
+	/**
+     * Get the Cached JsonPath
+     * @param key cache key to lookup the JsonPath
+     * @return JsonPath
+     */
+	public JsonPath get(String key);
+	
+	/**
+     * Add JsonPath to the cache
+     * @param key cache key to store the JsonPath
+     * @param value JsonPath to be cached
+     * @return void
+     * @throws InvalidJsonException
+     */
+	public void put(String key, JsonPath value);
+}

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/cache/DefaultCache.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/cache/DefaultCache.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jayway.jsonpath.spi.cache;
+
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+import com.jayway.jsonpath.JsonPath;
+
+/*
+ * LRU implementation copied from com.jayway.jsonpath.internal.Cache
+ * Will have the same bugs
+ */
+
+public class DefaultCache implements CacheProvider{
+
+    private final ReentrantLock lock = new ReentrantLock();
+
+    private final Map<String, JsonPath> map = new ConcurrentHashMap<String, JsonPath>();
+    private final Deque<String> queue = new LinkedList<String>();
+    private final int limit;
+
+    public DefaultCache(int limit) {
+        this.limit = limit;
+    }
+
+    public void put(String key, JsonPath value) {
+        JsonPath oldValue = map.put(key, value);
+        if (oldValue != null) {
+            removeThenAddKey(key);
+        } else {
+            addKey(key);
+        }
+        if (map.size() > limit) {
+            map.remove(removeLast());
+        }
+    }
+
+    public JsonPath get(String key) {
+        if(map.containsKey(key)){
+            removeThenAddKey(key);
+        }
+        return map.get(key);
+    }
+
+    private void addKey(String key) {
+        lock.lock();
+        try {
+            queue.addFirst(key);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private String removeLast() {
+        lock.lock();
+        try {
+            final String removedKey = queue.removeLast();
+            return removedKey;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void removeThenAddKey(String key) {
+        lock.lock();
+        try {
+            queue.removeFirstOccurrence(key);
+            queue.addFirst(key);
+        } finally {
+            lock.unlock();
+        }
+
+    }
+
+    private void removeFirstOccurrence(String key) {
+        lock.lock();
+        try {
+            queue.removeFirstOccurrence(key);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public JsonPath getSilent(String key) {
+        return map.get(key);
+    }
+
+    public void remove(String key) {
+        removeFirstOccurrence(key);
+        map.remove(key);
+    }
+
+    public int size() {
+        return map.size();
+    }
+
+    public String toString() {
+        return map.toString();
+    }
+}

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/JsonReaderTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/JsonReaderTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import com.jayway.jsonpath.BaseTest;
 import com.jayway.jsonpath.Criteria;
+import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.Filter;
 import com.jayway.jsonpath.JsonPath;
 
@@ -19,9 +20,11 @@ public class JsonReaderTest extends BaseTest {
 
         Filter feq = Filter.filter(Criteria.where("category").eq("reference"));
         Filter fne = Filter.filter(Criteria.where("category").ne("reference"));
+        
+        DocumentContext JsonDoc = JsonPath.parse(JSON_DOCUMENT);
 
-        List<String> eq = JsonPath.parse(JSON_DOCUMENT).read("$.store.book[?].category", feq);
-        List<String> ne = JsonPath.parse(JSON_DOCUMENT).read("$.store.book[?].category", fne);
+        List<String> eq = JsonDoc.read("$.store.book[?].category", feq);
+        List<String> ne = JsonDoc.read("$.store.book[?].category", fne);
 
         Assertions.assertThat(eq).contains("reference");
         Assertions.assertThat(ne).doesNotContain("reference");

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/JsonReaderTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/JsonReaderTest.java
@@ -1,0 +1,30 @@
+package com.jayway.jsonpath.internal;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import com.jayway.jsonpath.BaseTest;
+import com.jayway.jsonpath.Criteria;
+import com.jayway.jsonpath.Filter;
+import com.jayway.jsonpath.JsonPath;
+
+public class JsonReaderTest extends BaseTest {
+
+	@Test
+    public void cached_path_with_predicates() {
+
+        Filter feq = Filter.filter(Criteria.where("category").eq("reference"));
+        Filter fne = Filter.filter(Criteria.where("category").ne("reference"));
+
+        List<String> eq = JsonPath.parse(JSON_DOCUMENT).read("$.store.book[?].category", feq);
+        List<String> ne = JsonPath.parse(JSON_DOCUMENT).read("$.store.book[?].category", fne);
+
+        Assertions.assertThat(eq).contains("reference");
+        Assertions.assertThat(ne).doesNotContain("reference");
+    }
+
+}


### PR DESCRIPTION
Externalize cache to CacheProvider spi #94

Ideally I believe caching should be left to the user of the library, but disabling cache completely will probably impact the users who have come to depend on it. With these changes, Cache defaults to the (copy of) existing Cache implementation.

JsonPath.compile(String jsonPath, Predicate... filters) will not hit the cache. I don't think any existing user calling the JsonPath.compile instead of JsonPath.read expects to hit a cache. Also JsonPath.compile is the ideal way to allow the user to build their cache.

To plug-in a cache user will need to setup the CacheProvider in the configuration. 
Configuration
            .builder()
            .mappingProvider(new Implementation of mapping provider)
            .jsonProvider(new Implementation of JsonProvider)
            .cacheProvider(new implementation of CacheProvider)
            .build();