### PR TITLE
Speed up the abort of an evaluation

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/EvaluationAbortException.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/EvaluationAbortException.java
@@ -1,4 +1,13 @@
 package com.jayway.jsonpath.internal;
 
 public class EvaluationAbortException extends RuntimeException {
+
+  private static final long serialVersionUID = 4419305302960432348L;
+
+  // this is just a marker exception to abort evaluation, we don't care about
+  // the stack
+  @Override
+  public Throwable fillInStackTrace() {
+    return this;
+  }
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/EvaluationContextImpl.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/EvaluationContextImpl.java
@@ -38,6 +38,8 @@ import static com.jayway.jsonpath.internal.Utils.notNull;
  */
 public class EvaluationContextImpl implements EvaluationContext {
 
+    private static final EvaluationAbortException ABORT_EVALUATION = new EvaluationAbortException();
+
     private final Configuration configuration;
     private final Object valueResult;
     private final Object pathResult;
@@ -84,7 +86,7 @@ public class EvaluationContextImpl implements EvaluationContext {
             for (EvaluationListener listener : configuration().getEvaluationListeners()) {
                 EvaluationListener.EvaluationContinuation continuation = listener.resultFound(new FoundResultImpl(idx, path, model));
                 if(EvaluationListener.EvaluationContinuation.ABORT == continuation){
-                    throw new EvaluationAbortException();
+                    throw ABORT_EVALUATION;
                 }
             }
         }


### PR DESCRIPTION
It's quite expensive to create an exception and fill its stack. As we don't care about the stack anyway, we don't fill it, also we cache a single exception instance.
See http://java-performance.info/throwing-an-exception-in-java-is-very-slow/ for more info