### PR TITLE
Make `org.apache.tapestry5.json.*` optional in the manifest

### DIFF
--- a/json-path/build.gradle
+++ b/json-path/build.gradle
@@ -9,7 +9,7 @@ jar {
     baseName 'json-path'
     manifest {
         attributes 'Implementation-Title': 'json-path', 'Implementation-Version': version
-		instruction 'Import-Package', 'org.json.*;resolution:=optional', 'com.google.gson.*;resolution:=optional', 'com.fasterxml.jackson.*;resolution:=optional', 'net.minidev.json.*;resolution:=optional', '*'
+        instruction 'Import-Package', 'org.json.*;resolution:=optional', 'com.google.gson.*;resolution:=optional', 'com.fasterxml.jackson.*;resolution:=optional', 'net.minidev.json.*;resolution:=optional', 'org.apache.tapestry5.json.*;resolution:=optional', '*'
     }
 }
 


### PR DESCRIPTION
This should fix #207 and #208.