### PR TITLE
Property must be separated by commas

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
@@ -576,7 +576,8 @@ public class PathCompiler {
                 break;
             } else if (c == potentialStringDelimiter) {
                 if (inProperty && !inEscape) {
-                    if (!path.nextSignificantCharIs(readPosition, COMMA) && !path.nextSignificantCharIs(readPosition, CLOSE_SQUARE_BRACKET)) {
+                    char nextSignificantChar = path.nextSignificantChar(readPosition);
+                    if (nextSignificantChar != CLOSE_SQUARE_BRACKET && nextSignificantChar != COMMA) {
                         fail("Property must be separated by comma or Property must be terminated close square bracket at index "+readPosition);
                     }
                     endPosition = readPosition;

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
@@ -576,6 +576,9 @@ public class PathCompiler {
                 break;
             } else if (c == potentialStringDelimiter) {
                 if (inProperty && !inEscape) {
+                    if (!path.nextSignificantCharIs(readPosition, COMMA) && !path.nextSignificantCharIs(readPosition, CLOSE_SQUARE_BRACKET)) {
+                        fail("Property must be separated by comma or Property must be terminated close square bracket at index "+readPosition);
+                    }
                     endPosition = readPosition;
                     String prop = path.subSequence(startPosition, endPosition).toString();
                     properties.add(Utils.unescape(prop));

--- a/json-path/src/test/java/com/jayway/jsonpath/PathCompilerTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/PathCompilerTest.java
@@ -266,4 +266,9 @@ public class PathCompilerTest {
     public void accept_only_a_single_comma_between_indexes() {
         compile("$['1', ,'3']");
     }
+
+    @Test(expected = InvalidPathException.class)
+    public void property_must_be_separated_by_commas() {
+        compile("$['aaa'}'bbb']");
+    }
 }


### PR DESCRIPTION
Multi properties must be separated by comma.
So, It must be raised the InvalidPathException in the following case.

`$['aaa'}'bbb']`

Do you have any thoughts?
