### PR TITLE
Allow ReadContext to be matched by isJson()/hasJsonPath() matchers - issue #254

### DIFF
--- a/json-path-assert/src/main/java/com/jayway/jsonpath/matchers/IsJson.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonpath/matchers/IsJson.java
@@ -58,6 +58,8 @@ public class IsJson<T> extends TypeSafeMatcher<T> {
             return JsonPath.parse((String) object);
         } else if (object instanceof File) {
             return JsonPath.parse((File) object);
+        } else if (object instanceof ReadContext) {
+            return (ReadContext) object;
         } else {
             return JsonPath.parse(object);
         }

--- a/json-path-assert/src/test/java/com/jayway/jsonpath/matchers/JsonPathMatchersTest.java
+++ b/json-path-assert/src/test/java/com/jayway/jsonpath/matchers/JsonPathMatchersTest.java
@@ -1,6 +1,8 @@
 package com.jayway.jsonpath.matchers;
 
 import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.ReadContext;
 import com.jayway.jsonpath.matchers.helpers.StrictParsingConfiguration;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -208,5 +210,14 @@ public class JsonPathMatchersTest {
     public void shouldMatchJsonPathOnParsedJsonObject() {
         Object json = Configuration.defaultConfiguration().jsonProvider().parse(BOOKS_JSON);
         assertThat(json, hasJsonPath("$.store.name", equalTo("Little Shop")));
+    }
+
+    @Test
+    public void shouldMatchJsonPathOnReadContext() {
+        String test = "{\"foo\":\"bar\"}";
+        ReadContext context = JsonPath.parse(test);
+        assertThat(context, hasJsonPath("$.foo"));
+        assertThat(context, hasJsonPath("$.foo", equalTo("bar")));
+        assertThat(context, hasNoJsonPath("$.zoo"));
     }
 }


### PR DESCRIPTION
Currently it's possible to match on ReadContext using the withJsonPath()/withoutJsonPath()-matchers.

This PR makes it possible to also use isJson()/hasJsonPath()-matchers to match on ReadContext, i.e making them more liberal in what they would accept as input. 

See issue #254.