### PR TITLE
allowing single quotes in 'in' filter with Jackson JSON provider

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonNodeJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonNodeJsonProvider.java
@@ -1,5 +1,6 @@
 package com.jayway.jsonpath.spi.json;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -20,7 +21,13 @@ import java.util.List;
 
 public class JacksonJsonNodeJsonProvider extends AbstractJsonProvider {
 
-    private static final ObjectMapper defaultObjectMapper = new ObjectMapper();
+    private static final ObjectMapper defaultObjectMapper = createDefaultObjectMapper();
+
+    private static ObjectMapper createDefaultObjectMapper() {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+        return mapper;
+    }
 
     protected ObjectMapper objectMapper;
 

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonProvider.java
@@ -15,6 +15,7 @@
 package com.jayway.jsonpath.spi.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.jayway.jsonpath.InvalidJsonException;
@@ -29,7 +30,14 @@ import java.util.List;
 
 public class JacksonJsonProvider extends AbstractJsonProvider {
 
-    private static final ObjectMapper defaultObjectMapper = new ObjectMapper();
+    private static final ObjectMapper defaultObjectMapper = createDefaultObjectMapper();
+
+    private static ObjectMapper createDefaultObjectMapper() {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+        return mapper;
+    }
+
     private static final ObjectReader defaultObjectReader = defaultObjectMapper.reader().withType(Object.class);
 
     protected ObjectMapper objectMapper;

--- a/json-path/src/test/java/com/jayway/jsonpath/JacksonJsonNodeJsonProviderTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JacksonJsonNodeJsonProviderTest.java
@@ -52,7 +52,7 @@ public class JacksonJsonNodeJsonProviderTest extends BaseTest {
         context.put("$", "child", child1);
         ObjectNode node2 = context.read("$");
         ObjectNode child2 = context.read("$.child");
-        
+
         assertThat(node1).isSameAs(node2);
         assertThat(child1).isSameAs(child2);
     }
@@ -108,6 +108,15 @@ public class JacksonJsonNodeJsonProviderTest extends BaseTest {
         TypeRef<List<FooBarBaz<Integer>>> typeRef = new TypeRef<List<FooBarBaz<Integer>>>() {};
 
         using(JACKSON_JSON_NODE_CONFIGURATION).parse(JSON).read("$", typeRef);
+    }
+
+    @Test
+    public void jackson_json_allows_single_quotes() {
+        final String jsonArray = "[{\"foo\": \"bar\"}, {\"foo\": \"baz\"}]";
+        final Object readFromSingleQuote = using(JACKSON_JSON_NODE_CONFIGURATION).parse(jsonArray).read("$.[?(@.foo in ['bar'])].foo");
+        final Object readFromDoubleQuote = using(JACKSON_JSON_NODE_CONFIGURATION).parse(jsonArray).read("$.[?(@.foo in [\"bar\"])].foo");
+        assertThat(readFromSingleQuote).isEqualTo(readFromDoubleQuote);
+
     }
 
     public static class FooBarBaz<T> {

--- a/json-path/src/test/java/com/jayway/jsonpath/JacksonTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JacksonTest.java
@@ -45,4 +45,12 @@ public class JacksonTest extends BaseTest {
         assertThat(date).isEqualTo(now);
     }
 
+    @Test
+    public void jackson_allows_single_quotes() {
+        final String jsonArray = "[{\"foo\": \"bar\"}, {\"foo\": \"baz\"}]";
+        final Object readFromSingleQuote = JsonPath.using(JACKSON_CONFIGURATION).parse(jsonArray).read("$.[?(@.foo in ['bar'])].foo");
+        final Object readFromDoubleQuote = JsonPath.using(JACKSON_CONFIGURATION).parse(jsonArray).read("$.[?(@.foo in [\"bar\"])].foo");
+        assertThat(readFromSingleQuote).isEqualTo(readFromDoubleQuote);
+
+    }
 }


### PR DESCRIPTION
The filter values in the 'in' filter are treated as JSON. Single quotes in a JSON array are technically not valid JSON. Some JSON parsers allow it by default, others don't. Jackson does not. For consistency this pull-request enables single quotes for Jackson providers. This fixes https://github.com/jayway/JsonPath/issues/275