### PR TITLE
A JsonPath statement works with the Jackson Configuraiton, but not with Gson

### DIFF
--- a/json-path/src/test/java/com/jayway/jsonpath/BaseTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/BaseTest.java
@@ -53,20 +53,20 @@ public class BaseTest {
             .mappingProvider(new JsonSmartMappingProvider())
             .jsonProvider(new JsonSmartJsonProvider())
             .build();
-    
+
     public static final Configuration TAPESTRY_JSON_CONFIGURATION = Configuration
-        .builder()
-        .mappingProvider(new TapestryMappingProvider())
-        .jsonProvider(TapestryJsonProvider.INSTANCE)
-        .build();
+            .builder()
+            .mappingProvider(new TapestryMappingProvider())
+            .jsonProvider(TapestryJsonProvider.INSTANCE)
+            .build();
 
     public static final String JSON_BOOK_DOCUMENT =
             "{ " +
-            "   \"category\" : \"reference\",\n" +
-            "   \"author\" : \"Nigel Rees\",\n" +
-            "   \"title\" : \"Sayings of the Century\",\n" +
-            "   \"display-price\" : 8.95\n" +
-            "}";
+                    "   \"category\" : \"reference\",\n" +
+                    "   \"author\" : \"Nigel Rees\",\n" +
+                    "   \"title\" : \"Sayings of the Century\",\n" +
+                    "   \"display-price\" : 8.95\n" +
+                    "}";
     public static final String JSON_DOCUMENT = "{\n" +
             "   \"string-property\" : \"string-value\", \n" +
             "   \"int-max-property\" : " + Integer.MAX_VALUE + ", \n" +
@@ -117,6 +117,67 @@ public class BaseTest {
             "   \"foo\" : \"bar\",\n" +
             "   \"@id\" : \"ID\"\n" +
             "}";
+
+    public static final String JSON_AWS_LAMBDA_CONTEXT = "{\n" +
+            "  \"body\": \"{\\\"test\\\":\\\"body\\\"}\",\n" +
+            "  \"resource\": \"/{proxy+}\",\n" +
+            "  \"requestContext\": {\n" +
+            "    \"resourceId\": \"123456\",\n" +
+            "    \"apiId\": \"1234567890\",\n" +
+            "    \"resourcePath\": \"/{proxy+}\",\n" +
+            "    \"httpMethod\": \"POST\",\n" +
+            "    \"requestId\": \"c6af9ac6-7b61-11e6-9a41-93e8deadbeef\",\n" +
+            "    \"accountId\": \"123456789012\",\n" +
+            "    \"identity\": {\n" +
+            "      \"apiKey\": null,\n" +
+            "      \"userArn\": null,\n" +
+            "      \"cognitoAuthenticationType\": null,\n" +
+            "      \"caller\": null,\n" +
+            "      \"userAgent\": \"Custom User Agent String\",\n" +
+            "      \"user\": null,\n" +
+            "      \"cognitoIdentityPoolId\": null,\n" +
+            "      \"cognitoIdentityId\": null,\n" +
+            "      \"cognitoAuthenticationProvider\": null,\n" +
+            "      \"sourceIp\": \"127.0.0.1\",\n" +
+            "      \"accountId\": null\n" +
+            "    },\n" +
+            "    \"stage\": \"prod\"\n" +
+            "  },\n" +
+            "  \"queryStringParameters\": {\n" +
+            "    \"lat\": 50.0,\n" +
+            "    \"lon\": 60.0,\n" +
+            "    \"timeZone\": 1\n" +
+            "  },\n" +
+            "  \"headers\": {\n" +
+            "    \"Via\": \"1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)\",\n" +
+            "    \"Accept-Language\": \"en-US,en;q=0.8\",\n" +
+            "    \"CloudFront-Is-Desktop-Viewer\": \"true\",\n" +
+            "    \"CloudFront-Is-SmartTV-Viewer\": \"false\",\n" +
+            "    \"CloudFront-Is-Mobile-Viewer\": \"false\",\n" +
+            "    \"X-Forwarded-For\": \"127.0.0.1, 127.0.0.2\",\n" +
+            "    \"CloudFront-Viewer-Country\": \"US\",\n" +
+            "    \"Accept\": \"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\",\n" +
+            "    \"Upgrade-Insecure-Requests\": \"1\",\n" +
+            "    \"X-Forwarded-Port\": \"443\",\n" +
+            "    \"Host\": \"1234567890.execute-api.us-east-1.amazonaws.com\",\n" +
+            "    \"X-Forwarded-Proto\": \"https\",\n" +
+            "    \"X-Amz-Cf-Id\": \"cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==\",\n" +
+            "    \"CloudFront-Is-Tablet-Viewer\": \"false\",\n" +
+            "    \"Cache-Control\": \"max-age=0\",\n" +
+            "    \"User-Agent\": \"Custom User Agent String\",\n" +
+            "    \"CloudFront-Forwarded-Proto\": \"https\",\n" +
+            "    \"Accept-Encoding\": \"gzip, deflate, sdch\"\n" +
+            "  },\n" +
+            "  \"pathParameters\": {\n" +
+            "    \"proxy\": \"path/to/resource\"\n" +
+            "  },\n" +
+            "  \"httpMethod\": \"POST\",\n" +
+            "  \"stageVariables\": {\n" +
+            "    \"baz\": \"qux\"\n" +
+            "  },\n" +
+            "  \"path\": \"/path/to/resource\"\n" +
+            "}";
+
 
     public Predicate.PredicateContext createPredicateContext(final Object check) {
 

--- a/json-path/src/test/java/com/jayway/jsonpath/GsonJsonProviderTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/GsonJsonProviderTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import static com.jayway.jsonpath.JsonPath.using;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,36 +17,36 @@ public class GsonJsonProviderTest extends BaseTest {
 
     private static final String JSON =
             "[" +
-            "{\n" +
-            "   \"foo\" : \"foo0\",\n" +
-            "   \"bar\" : 0,\n" +
-            "   \"baz\" : true,\n" +
-            "   \"gen\" : {\"eric\" : \"yepp\"}" +
-            "}," +
-            "{\n" +
-            "   \"foo\" : \"foo1\",\n" +
-            "   \"bar\" : 1,\n" +
-            "   \"baz\" : true,\n" +
-            "   \"gen\" : {\"eric\" : \"yepp\"}" +
-            "}," +
-            "{\n" +
-            "   \"foo\" : \"foo2\",\n" +
-            "   \"bar\" : 2,\n" +
-            "   \"baz\" : true,\n" +
-            "   \"gen\" : {\"eric\" : \"yepp\"}" +
-            "}" +
-            "]";
+                    "{\n" +
+                    "   \"foo\" : \"foo0\",\n" +
+                    "   \"bar\" : 0,\n" +
+                    "   \"baz\" : true,\n" +
+                    "   \"gen\" : {\"eric\" : \"yepp\"}" +
+                    "}," +
+                    "{\n" +
+                    "   \"foo\" : \"foo1\",\n" +
+                    "   \"bar\" : 1,\n" +
+                    "   \"baz\" : true,\n" +
+                    "   \"gen\" : {\"eric\" : \"yepp\"}" +
+                    "}," +
+                    "{\n" +
+                    "   \"foo\" : \"foo2\",\n" +
+                    "   \"bar\" : 2,\n" +
+                    "   \"baz\" : true,\n" +
+                    "   \"gen\" : {\"eric\" : \"yepp\"}" +
+                    "}" +
+                    "]";
 
     @Test
     public void json_can_be_parsed() {
-        JsonObject node =  using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$");
+        JsonObject node = using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$");
         assertThat(node.get("string-property").getAsString()).isEqualTo("string-value");
     }
 
     @Test
     public void strings_are_unwrapped() {
-        JsonElement node =  using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$.string-property");
-        String unwrapped =  using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$.string-property", String.class);
+        JsonElement node = using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$.string-property");
+        String unwrapped = using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$.string-property", String.class);
 
         assertThat(unwrapped).isEqualTo("string-value");
         assertThat(unwrapped).isEqualTo(node.getAsString());
@@ -53,8 +54,8 @@ public class GsonJsonProviderTest extends BaseTest {
 
     @Test
     public void ints_are_unwrapped() {
-        JsonElement node =  using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$.int-max-property");
-        int unwrapped =  using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$.int-max-property", int.class);
+        JsonElement node = using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$.int-max-property");
+        int unwrapped = using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$.int-max-property", int.class);
 
         assertThat(unwrapped).isEqualTo(Integer.MAX_VALUE);
         assertThat(unwrapped).isEqualTo(node.getAsInt());
@@ -62,8 +63,8 @@ public class GsonJsonProviderTest extends BaseTest {
 
     @Test
     public void longs_are_unwrapped() {
-        JsonElement node =  using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$.long-max-property");
-        long val =  using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$.long-max-property", Long.class);
+        JsonElement node = using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$.long-max-property");
+        long val = using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$.long-max-property", Long.class);
 
         assertThat(val).isEqualTo(Long.MAX_VALUE);
         assertThat(val).isEqualTo(node.getAsLong());
@@ -79,9 +80,20 @@ public class GsonJsonProviderTest extends BaseTest {
         assertThat(using(GSON_CONFIGURATION).parse("{\"val\": 1}").read("val", Double.class)).isEqualTo(1D);
     }
 
+
+    @Test(expected = ClassCastException.class)
+    public void jackson_can_what_gson_cannot() {
+        final Map<String, Object> jacksonMap = using(JACKSON_CONFIGURATION).parse(JSON_AWS_LAMBDA_CONTEXT).read("$.queryStringParameters");
+        assertThat(jacksonMap.get("lat")).isEqualTo(50D);
+
+        // thorws class ClassCastException
+        final Map<String, Object> gsonMap = using(GSON_CONFIGURATION).parse(JSON_AWS_LAMBDA_CONTEXT).read("$.queryStringParameters");
+        assertThat(gsonMap.get("lat")).isEqualTo(50D);
+    }
+
     @Test
     public void list_of_numbers() {
-        JsonArray objs =  using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$.store.book[*].display-price");
+        JsonArray objs = using(GSON_CONFIGURATION).parse(JSON_DOCUMENT).read("$.store.book[*].display-price");
 
         assertThat(objs.iterator()).extracting("asDouble").containsExactly(8.95D, 12.99D, 8.99D, 22.99D);
 
@@ -107,7 +119,8 @@ public class GsonJsonProviderTest extends BaseTest {
 
     @Test
     public void test_type_ref() throws IOException {
-        TypeRef<List<FooBarBaz<Gen>>> typeRef = new TypeRef<List<FooBarBaz<Gen>>>() {};
+        TypeRef<List<FooBarBaz<Gen>>> typeRef = new TypeRef<List<FooBarBaz<Gen>>>() {
+        };
 
         List<FooBarBaz<Gen>> list = JsonPath.using(GSON_CONFIGURATION).parse(JSON).read("$", typeRef);
 
@@ -116,7 +129,8 @@ public class GsonJsonProviderTest extends BaseTest {
 
     @Test(expected = MappingException.class)
     public void test_type_ref_fail() throws IOException {
-        TypeRef<List<FooBarBaz<Integer>>> typeRef = new TypeRef<List<FooBarBaz<Integer>>>() {};
+        TypeRef<List<FooBarBaz<Integer>>> typeRef = new TypeRef<List<FooBarBaz<Integer>>>() {
+        };
 
         using(GSON_CONFIGURATION).parse(JSON).read("$", typeRef);
     }
@@ -138,8 +152,6 @@ public class GsonJsonProviderTest extends BaseTest {
         public Long bar;
         public boolean baz;
     }
-
-
 
 
 }


### PR DESCRIPTION
I have provided a pull request with a unit test that shows that the expression

`
final Map<String, Object> params = ctx.read("$.queryStringParameters");
`
_(queryStringParameters is a Javascript Object)_

Manages to map the Json object to a map with the JacksonConfiguration, but when using GSON configuration the statement throws a ClassCastException, 

java.lang.ClassCastException: com.google.gson.JsonObject cannot be cast to java.util.Map

```
com.jayway.jsonpath.GsonJsonProviderTest.jackson_can_what_gson_cannot(GsonJsonProviderTest.java:90)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:51)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:237)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)

```