### PR TITLE
Exclude transitive ASM dependency

### DIFF
--- a/json-path/build.gradle
+++ b/json-path/build.gradle
@@ -14,7 +14,10 @@ jar {
 }
 
 dependencies {
-    compile libs.jsonSmart
+    compile (libs.jsonSmart){
+      // see https://github.com/jayway/JsonPath/issues/228, https://github.com/netplex/json-smart-v2/issues/20
+      exclude group: 'org.ow2.asm', module: 'asm' 
+    }
     compile libs.slf4jApi
     compile libs.jacksonDatabind, optional
     compile libs.gson, optional


### PR DESCRIPTION
We don't need the bean mapping features and it causes issues
Fixes #228, #224, #213