### PR TITLE
upgrade json-smart dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 ext {
     libs = [
             slf4jApi: 'org.slf4j:slf4j-api:1.7.16',
-            jsonSmart: 'net.minidev:json-smart:2.2.1',
+            jsonSmart: 'net.minidev:json-smart:2.3',
             jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.6.3',
             gson: 'com.google.code.gson:gson:2.3.1',
             jettison: 'org.codehaus.jettison:jettison:1.3.7',

--- a/json-path/build.gradle
+++ b/json-path/build.gradle
@@ -11,10 +11,7 @@ jar {
 }
 
 dependencies {
-    compile (libs.jsonSmart){
-      // see https://github.com/jayway/JsonPath/issues/228, https://github.com/netplex/json-smart-v2/issues/20
-      exclude group: 'org.ow2.asm', module: 'asm' 
-    }
+    compile libs.jsonSmart
     compile libs.slf4jApi
     compile libs.jacksonDatabind, optional
     compile libs.gson, optional


### PR DESCRIPTION
This reverts #315. ASM classes are no longer packaged with `accessors-smart` (see  netplex/json-smart-v2#35)
See also #228, #224, #213