### PR TITLE
Fix for Issue #234 - Late Binding for Function Parameters

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
@@ -21,7 +21,6 @@ import com.jayway.jsonpath.internal.Path;
 import com.jayway.jsonpath.internal.PathRef;
 import com.jayway.jsonpath.internal.Utils;
 import com.jayway.jsonpath.internal.path.PathCompiler;
-import com.jayway.jsonpath.spi.cache.Cache;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 
 import java.io.File;

--- a/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
@@ -21,6 +21,7 @@ import com.jayway.jsonpath.internal.Path;
 import com.jayway.jsonpath.internal.PathRef;
 import com.jayway.jsonpath.internal.Utils;
 import com.jayway.jsonpath.internal.path.PathCompiler;
+import com.jayway.jsonpath.spi.cache.Cache;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 
 import java.io.File;

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
@@ -146,8 +146,8 @@ public class JsonContext implements ParseContext, DocumentContext {
         if(jsonPath != null){
         	return read(jsonPath);
         } else {
-            jsonPath = compile(path, filters);
-            cache.put(cacheKey, jsonPath);
+                jsonPath = compile(path, filters);
+                cache.put(cacheKey, jsonPath);
         	return read(jsonPath);
         }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
@@ -26,7 +26,6 @@ import com.jayway.jsonpath.ReadContext;
 import com.jayway.jsonpath.TypeRef;
 import com.jayway.jsonpath.spi.cache.Cache;
 import com.jayway.jsonpath.spi.cache.CacheProvider;
-import com.jayway.jsonpath.spi.cache.LRUCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
@@ -146,8 +146,8 @@ public class JsonContext implements ParseContext, DocumentContext {
         if(jsonPath != null){
         	return read(jsonPath);
         } else {
-                jsonPath = compile(path, filters);
-                cache.put(cacheKey, jsonPath);
+		jsonPath = compile(path, filters);
+		cache.put(cacheKey, jsonPath);
         	return read(jsonPath);
         }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
@@ -26,6 +26,7 @@ import com.jayway.jsonpath.ReadContext;
 import com.jayway.jsonpath.TypeRef;
 import com.jayway.jsonpath.spi.cache.Cache;
 import com.jayway.jsonpath.spi.cache.CacheProvider;
+import com.jayway.jsonpath.spi.cache.LRUCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -146,8 +147,8 @@ public class JsonContext implements ParseContext, DocumentContext {
         if(jsonPath != null){
         	return read(jsonPath);
         } else {
-        	jsonPath = compile(path, filters);
-        	cache.put(cacheKey, jsonPath);
+            jsonPath = compile(path, filters);
+            cache.put(cacheKey, jsonPath);
         	return read(jsonPath);
         }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/Parameter.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/Parameter.java
@@ -1,6 +1,8 @@
 package com.jayway.jsonpath.internal.function;
 
 import com.jayway.jsonpath.internal.Path;
+import com.jayway.jsonpath.internal.function.latebinding.ILateBindingValue;
+import com.jayway.jsonpath.internal.function.latebinding.PathLateBindingValue;
 
 /**
  * Created by matt@mjgreenwood.net on 12/10/15.
@@ -8,7 +10,7 @@ import com.jayway.jsonpath.internal.Path;
 public class Parameter {
     private ParamType type;
     private Path path;
-    private Object cachedValue;
+    private ILateBindingValue lateBinding;
     private Boolean evaluated = false;
     private String json;
 
@@ -24,12 +26,12 @@ public class Parameter {
         this.type = ParamType.PATH;
     }
 
-    public Object getCachedValue() {
-        return cachedValue;
+    public Object getValue() {
+        return lateBinding.get();
     }
 
-    public void setCachedValue(Object cachedValue) {
-        this.cachedValue = cachedValue;
+    public void setLateBinding(ILateBindingValue lateBinding) {
+        this.lateBinding = lateBinding;
     }
 
     public Path getPath() {

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/json/Append.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/json/Append.java
@@ -22,7 +22,7 @@ public class Append implements PathFunction {
             for (Parameter param : parameters) {
                 if (jsonProvider.isArray(model)) {
                     int len = jsonProvider.length(model);
-                    jsonProvider.setArrayIndex(model, len, param.getCachedValue());
+                    jsonProvider.setArrayIndex(model, len, param.getValue());
                 }
             }
         }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/ILateBindingValue.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/ILateBindingValue.java
@@ -6,5 +6,13 @@ package com.jayway.jsonpath.internal.function.latebinding;
  * Created by mattg on 3/27/17.
  */
 public interface ILateBindingValue {
+    /**
+     * Obtain the value of the parameter at runtime using the parameter state and invocation of other late binding values
+     * rather than maintaining cached state which ends up in a global store and won't change as a result of external
+     * reference changes.
+     *
+     * @return
+     *      The value of evaluating the context at runtime.
+     */
     Object get();
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/ILateBindingValue.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/ILateBindingValue.java
@@ -1,9 +1,22 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.jayway.jsonpath.internal.function.latebinding;
 
 /**
  * Obtain the late binding value at runtime rather than storing the value in the cache thus trashing the cache
  *
- * Created by mattg on 3/27/17.
  */
 public interface ILateBindingValue {
     /**

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/ILateBindingValue.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/ILateBindingValue.java
@@ -1,0 +1,10 @@
+package com.jayway.jsonpath.internal.function.latebinding;
+
+/**
+ * Obtain the late binding value at runtime rather than storing the value in the cache thus trashing the cache
+ *
+ * Created by mattg on 3/27/17.
+ */
+public interface ILateBindingValue {
+    Object get();
+}

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/JsonLateBindingValue.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/JsonLateBindingValue.java
@@ -1,0 +1,22 @@
+package com.jayway.jsonpath.internal.function.latebinding;
+
+import com.jayway.jsonpath.internal.function.Parameter;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+
+/**
+ * Created by mattg on 3/27/17.
+ */
+public class JsonLateBindingValue implements ILateBindingValue {
+    private final JsonProvider jsonProvider;
+    private final Parameter jsonParameter;
+
+    public JsonLateBindingValue(JsonProvider jsonProvider, Parameter jsonParameter) {
+        this.jsonProvider = jsonProvider;
+        this.jsonParameter = jsonParameter;
+    }
+
+    @Override
+    public Object get() {
+        return jsonProvider.parse(jsonParameter.getJson());
+    }
+}

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/JsonLateBindingValue.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/JsonLateBindingValue.java
@@ -15,6 +15,12 @@ public class JsonLateBindingValue implements ILateBindingValue {
         this.jsonParameter = jsonParameter;
     }
 
+    /**
+     * Evaluate the JSON document at the point of need using the JSON parameter and associated document model which may
+     * itself originate from yet another function thus recursively invoking late binding methods.
+     * 
+     * @return
+     */
     @Override
     public Object get() {
         return jsonProvider.parse(jsonParameter.getJson());

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/JsonLateBindingValue.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/JsonLateBindingValue.java
@@ -1,10 +1,25 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.jayway.jsonpath.internal.function.latebinding;
 
 import com.jayway.jsonpath.internal.function.Parameter;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 
 /**
- * Created by mattg on 3/27/17.
+ * Defines the JSON document Late binding approach to function arguments.
+ *
  */
 public class JsonLateBindingValue implements ILateBindingValue {
     private final JsonProvider jsonProvider;

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/JsonLateBindingValue.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/JsonLateBindingValue.java
@@ -18,7 +18,7 @@ public class JsonLateBindingValue implements ILateBindingValue {
     /**
      * Evaluate the JSON document at the point of need using the JSON parameter and associated document model which may
      * itself originate from yet another function thus recursively invoking late binding methods.
-     * 
+     *
      * @return
      */
     @Override

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
@@ -24,7 +24,8 @@ public class PathLateBindingValue implements ILateBindingValue {
     }
 
     /**
-     * Evaluate the field type
+     * Evaluate the expression at the point of need for Path type expressions
+     *
      * @return
      */
     public Object get() {

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
@@ -17,7 +17,7 @@ public class PathLateBindingValue implements ILateBindingValue {
     private final Object rootDocument;
     private final Configuration configuration;
 
-    public PathLateBindingValue(ParamType type, Path path, Object rootDocument, Configuration configuration) {
+    public PathLateBindingValue(final Path path, final Object rootDocument, final Configuration configuration) {
         this.path = path;
         this.rootDocument = rootDocument;
         this.configuration = configuration;

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.jayway.jsonpath.internal.function.latebinding;
 
 import com.jayway.jsonpath.Configuration;
@@ -10,7 +24,6 @@ import com.jayway.jsonpath.internal.function.ParamType;
  *
  * Acts like a lambda function with references, but since we're supporting JDK 6+, we're left doing this...
  *
- * Created by mattg on 3/27/17.
  */
 public class PathLateBindingValue implements ILateBindingValue {
     private final Path path;

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
@@ -1,0 +1,33 @@
+package com.jayway.jsonpath.internal.function.latebinding;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.internal.Path;
+import com.jayway.jsonpath.internal.function.ParamType;
+
+/**
+ * Defines the contract for late bindings, provides document state and enough context to perform the evaluation at a later
+ * date such that we can operate on a dynamically changing value.
+ *
+ * Acts like a lambda function with references, but since we're supporting JDK 6+, we're left doing this...
+ *
+ * Created by mattg on 3/27/17.
+ */
+public class PathLateBindingValue implements ILateBindingValue {
+    private final Path path;
+    private final Object rootDocument;
+    private final Configuration configuration;
+
+    public PathLateBindingValue(ParamType type, Path path, Object rootDocument, Configuration configuration) {
+        this.path = path;
+        this.rootDocument = rootDocument;
+        this.configuration = configuration;
+    }
+
+    /**
+     * Evaluate the field type
+     * @return
+     */
+    public Object get() {
+        return path.evaluate(rootDocument, rootDocument, configuration).getValue();
+    }
+}

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/numeric/AbstractAggregation.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/numeric/AbstractAggregation.java
@@ -49,10 +49,10 @@ public abstract class AbstractAggregation implements PathFunction {
         }
         if (parameters != null) {
             for (Parameter param : parameters) {
-                if (param.getValue() instanceof Number) {
-                    Number value = (Number)param.getValue();
+                Object value = param.getValue();
+                if (null != value && value instanceof Number) {
                     count++;
-                    next(value);
+                    next((Number)value);
                 }
             }
         }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/numeric/AbstractAggregation.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/numeric/AbstractAggregation.java
@@ -49,8 +49,8 @@ public abstract class AbstractAggregation implements PathFunction {
         }
         if (parameters != null) {
             for (Parameter param : parameters) {
-                if (param.getCachedValue() instanceof Number) {
-                    Number value = (Number)param.getCachedValue();
+                if (param.getValue() instanceof Number) {
+                    Number value = (Number)param.getValue();
                     count++;
                     next(value);
                 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/text/Concatenate.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/text/Concatenate.java
@@ -27,8 +27,8 @@ public class Concatenate implements PathFunction {
         }
         if (parameters != null) {
             for (Parameter param : parameters) {
-                if (param.getCachedValue() != null) {
-                    result.append(param.getCachedValue().toString());
+                if (param.getValue() != null) {
+                    result.append(param.getValue().toString());
                 }
             }
         }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/text/Concatenate.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/text/Concatenate.java
@@ -27,8 +27,9 @@ public class Concatenate implements PathFunction {
         }
         if (parameters != null) {
             for (Parameter param : parameters) {
-                if (param.getValue() != null) {
-                    result.append(param.getValue().toString());
+		Object value = param.getValue();
+                if (value != null) {
+                    result.append(value.toString());
                 }
             }
         }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/FunctionPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/FunctionPathToken.java
@@ -51,12 +51,10 @@ public class FunctionPathToken extends PathToken {
                 if (!param.hasEvaluated()) {
                     switch (param.getType()) {
                         case PATH:
-                            //param.setCachedValue(param.getPath().evaluate(ctx.rootDocument(), ctx.rootDocument(), ctx.configuration()).getValue());
                             param.setLateBinding(new PathLateBindingValue(param.getType(), param.getPath(), ctx.rootDocument(), ctx.configuration()));
                             param.setEvaluated(true);
                             break;
                         case JSON:
-//                            ctx.configuration().jsonProvider().parse(param.getJson())
                             param.setLateBinding(new JsonLateBindingValue(ctx.configuration().jsonProvider(), param));
                             param.setEvaluated(true);
                             break;

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/FunctionPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/FunctionPathToken.java
@@ -51,7 +51,7 @@ public class FunctionPathToken extends PathToken {
                 if (!param.hasEvaluated()) {
                     switch (param.getType()) {
                         case PATH:
-                            param.setLateBinding(new PathLateBindingValue(param.getType(), param.getPath(), ctx.rootDocument(), ctx.configuration()));
+                            param.setLateBinding(new PathLateBindingValue(param.getPath(), ctx.rootDocument(), ctx.configuration()));
                             param.setEvaluated(true);
                             break;
                         case JSON:

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/FunctionPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/FunctionPathToken.java
@@ -4,6 +4,8 @@ import com.jayway.jsonpath.internal.PathRef;
 import com.jayway.jsonpath.internal.function.Parameter;
 import com.jayway.jsonpath.internal.function.PathFunction;
 import com.jayway.jsonpath.internal.function.PathFunctionFactory;
+import com.jayway.jsonpath.internal.function.latebinding.JsonLateBindingValue;
+import com.jayway.jsonpath.internal.function.latebinding.PathLateBindingValue;
 
 import java.util.List;
 
@@ -49,11 +51,13 @@ public class FunctionPathToken extends PathToken {
                 if (!param.hasEvaluated()) {
                     switch (param.getType()) {
                         case PATH:
-                            param.setCachedValue(param.getPath().evaluate(ctx.rootDocument(), ctx.rootDocument(), ctx.configuration()).getValue());
+                            //param.setCachedValue(param.getPath().evaluate(ctx.rootDocument(), ctx.rootDocument(), ctx.configuration()).getValue());
+                            param.setLateBinding(new PathLateBindingValue(param.getType(), param.getPath(), ctx.rootDocument(), ctx.configuration()));
                             param.setEvaluated(true);
                             break;
                         case JSON:
-                            param.setCachedValue(ctx.configuration().jsonProvider().parse(param.getJson()));
+//                            ctx.configuration().jsonProvider().parse(param.getJson())
+                            param.setLateBinding(new JsonLateBindingValue(ctx.configuration().jsonProvider(), param));
                             param.setEvaluated(true);
                             break;
                     }

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue234.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue234.java
@@ -1,0 +1,39 @@
+package com.jayway.jsonpath.internal.function;
+
+import com.jayway.jsonpath.JsonPath;
+import org.assertj.core.util.Maps;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * TDD for Issue #234
+ *
+ * Verifies the use-case where-in the function path expression is cached and re-used but the JsonPath includes a function
+ * whose arguments are then dependent upon state that changes externally from the internal Cache.getCache state.  The
+ * prior implementation had a bug where-in the parameter values were cached -- the present implementation (as of Issue #234)
+ * now uses a late binding approach to eval the function parameters.  Cache invalidation isn't an option given the need
+ * for nested function calls.
+ *
+ * Once this bug is fixed, most of the concern then centers around the need to ensure nested functions are processed
+ * correctly.
+ *
+ * @see NestedFunctionTest for examples of where that is performed.
+ *
+ * Created by mattg on 3/27/17.
+ */
+public class Issue234 {
+
+    @Test
+    public void testIssue234() {
+        Map<String, String> context = Maps.newHashMap();
+        context.put("key", "first");
+        Object value = JsonPath.read(context, "concat(\"/\", $.key)");
+        assertThat(value).isEqualTo("/first");
+        context.put("key", "second");
+        value = JsonPath.read(context, "concat(\"/\", $.key)");
+        assertThat(value).isEqualTo("/second");
+    }
+}

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue234.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue234.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @see NestedFunctionTest for examples of where that is performed.
  *
- * Created by mattg on 3/27/17.
  */
 public class Issue234 {
 


### PR DESCRIPTION
Fixes Issue #234 using late binding, ideally this might be a lambda that encapsulates its state -- given support for JDK 6+, its encapsulated state is maintained in an implementation of the interface ILateBindingValue, one for PATH functions one for JSON - its likely the JSON version doesn't have a purpose unless the JSON dynamically changes as a result of the function implementation but its better to create another impl for JSON if in the future JSON can be dynamically changed via functions(?)
    
    The fault is in the Parameter object which obviously cached its value and when the outside reference changes its oblivious to that state change due to its internal cached instance of the state.    Cache.getCache()... that singleton call inside of JsonContext then grabs an instance of the cached parameter, it would be thread unsafe to simple invalidate the cache because who knows for whom the cache is being invalidated.
    
    Not caching function paths isn't an answer -- the input to a function could itself be another function - meaning the input (parameter) value would never be observed to the wrapping function and things such as take the $.max(3, 4, 5, $.avg(...)) would yield an answer without average being computed.
